### PR TITLE
M704 run custom g-code macro

### DIFF
--- a/src/GCodes/GCodes2.cpp
+++ b/src/GCodes/GCodes2.cpp
@@ -1203,6 +1203,7 @@ bool GCodes::HandleMcode(GCodeBuffer& gb, const StringRef& reply)
 		}
 		break;
 
+
 	case 99: // Return from Macro/Subprogram
 		FileMacroCyclesReturn(gb);
 		break;
@@ -3864,6 +3865,28 @@ bool GCodes::HandleMcode(GCodeBuffer& gb, const StringRef& reply)
 		{
 			result = GCodeResult::error;
 			reply.copy("No tool selected");
+		}
+		break;
+
+	case 704: // Run custom filament macro
+		if (gb.Seen('P'))
+		{
+			if (reprap.GetCurrentTool() != nullptr)
+			{
+				if (reprap.GetCurrentTool()->GetFilament() != nullptr)
+				{
+					String<MaxFilenameLength> filename;
+					gb.GetPossiblyQuotedString(filename.GetRef());
+					String<ScratchStringLength> scratchString;
+					scratchString.printf("%s%s/%s", FILAMENTS_DIRECTORY, reprap.GetCurrentTool()->GetFilament()->GetName(), filename.c_str());
+					DoFileMacro(gb, scratchString.c_str(), true);
+				}
+			}
+			else
+			{
+				result = GCodeResult::error;
+				reply.copy("No tool selected");
+			}
 		}
 		break;
 


### PR DESCRIPTION
add M704 command to run custom macro from current loaded filament
This is a follow to my post https://forum.duet3d.com/topic/8887/run-custom-macro-for-loaded-filament
I deiced I will give a try and implement it. Seems to work fine, even when the file isn't found or no filament is loaded. 