### PR TITLE
Make spindle speed sticky …

### DIFF
--- a/src/GCodes/GCodes2.cpp
+++ b/src/GCodes/GCodes2.cpp
@@ -393,13 +393,11 @@ bool GCodes::HandleMcode(GCodeBuffer& gb, const StringRef& reply)
 		break;
 
 	case 3: // Spin spindle clockwise
-		if (gb.Seen('S'))
 		{
 			switch (machineType)
 			{
 			case MachineType::cnc:
 				{
-					const float rpm = gb.GetFValue();
 					const uint32_t slot = gb.Seen('P') ? gb.GetUIValue() : 0;
 					if (slot >= MaxSpindles)
 					{
@@ -408,18 +406,25 @@ bool GCodes::HandleMcode(GCodeBuffer& gb, const StringRef& reply)
 					}
 					else
 					{
-						platform.AccessSpindle(slot).SetRpm(rpm);
+						if (gb.Seen('S'))
+						{
+							const float rpm = gb.GetFValue();
+							platform.AccessSpindle(slot).SetRpm(rpm);
+						}
+						platform.AccessSpindle(slot).TurnOn();
 					}
 				}
 				break;
 
 			case MachineType::laser:
-				platform.SetLaserPwm(ConvertLaserPwm(gb.GetFValue()));
+				if (gb.Seen('S')) {
+					platform.SetLaserPwm(ConvertLaserPwm(gb.GetFValue()));
+				}
 				break;
 
 			default:
 #if SUPPORT_ROLAND
-				if (reprap.GetRoland()->Active())
+				if (gb.Seen('S') && reprap.GetRoland()->Active())
 				{
 					result = reprap.GetRoland()->ProcessSpindle(gb.GetFValue());
 				}
@@ -434,11 +439,9 @@ bool GCodes::HandleMcode(GCodeBuffer& gb, const StringRef& reply)
 		break;
 
 	case 4: // Spin spindle counter clockwise
-		if (gb.Seen('S'))
 		{
 			if (machineType == MachineType::cnc)
 			{
-				const float rpm = gb.GetFValue();
 				const uint32_t slot = gb.Seen('P') ? gb.GetUIValue() : 0;
 				if (slot >= MaxSpindles)
 				{
@@ -447,7 +450,13 @@ bool GCodes::HandleMcode(GCodeBuffer& gb, const StringRef& reply)
 				}
 				else
 				{
-					platform.AccessSpindle(slot).SetRpm(-rpm);
+					if (gb.Seen('S'))
+					{
+						const float rpm = gb.GetFValue();
+						platform.AccessSpindle(slot).SetRpm(-rpm);
+					}
+					platform.AccessSpindle(slot).TurnOn();
+
 				}
 			}
 			else

--- a/src/Spindle.cpp
+++ b/src/Spindle.cpp
@@ -33,8 +33,13 @@ void Spindle::SetPwmFrequency(float freq)
 
 void Spindle::SetRpm(float rpm)
 {
-	const float pwm = abs(rpm / maxRpm);
-	if (rpm >= 0.0)
+	configuredRpm = rpm;
+}
+
+void Spindle::TurnOn()
+{
+	const float pwm = abs(configuredRpm / maxRpm);
+	if (configuredRpm >= 0.0)
 	{
 		spindleReversePort.WriteAnalog(0.0);
 		spindleForwardPort.WriteAnalog(pwm);
@@ -44,7 +49,7 @@ void Spindle::SetRpm(float rpm)
 		spindleReversePort.WriteAnalog(pwm);
 		spindleForwardPort.WriteAnalog(0.0);
 	}
-	currentRpm = configuredRpm = rpm;
+	currentRpm = configuredRpm;
 }
 
 void Spindle::TurnOff()
@@ -53,5 +58,7 @@ void Spindle::TurnOff()
 	spindleForwardPort.WriteAnalog(0.0);
 	currentRpm = 0.0;
 }
+
+
 
 // End

--- a/src/Spindle.h
+++ b/src/Spindle.h
@@ -35,6 +35,7 @@ public:
 	float GetRpm() const { return configuredRpm; }
 	void SetRpm(float rpm);
 
+	void TurnOn();
 	void TurnOff();
 };
 


### PR DESCRIPTION
This commit makes the spindle speed sticky so that you can restart the spindle  M3 o M4 command without an S parameter and get the speed that was last in use.

This is very helpful  in the pause/resume macros so you can stop the spindle and restart it back to the previous speed.  - I use this for manual tool changing.