### PR TITLE
Reenable TOFF=0 when using M569 Cnnn

### DIFF
--- a/src/Movement/StepperDrivers/TMC22xx.cpp
+++ b/src/Movement/StepperDrivers/TMC22xx.cpp
@@ -275,7 +275,7 @@ public:
 	void UartTmcHandler();									// core of the ISR for this driver
 
 private:
-	bool SetChopConf(uint32_t newVal);
+	bool SetChopConf(uint32_t newVal, bool raw = false);
 	void UpdateRegister(size_t regIndex, uint32_t regVal);
 	void UpdateChopConfRegister();							// calculate the chopper control register and flag it for sending
 	void UpdateCurrent();
@@ -547,7 +547,7 @@ bool TmcDriverState::SetRegister(SmartDriverRegister reg, uint32_t regVal)
 	switch(reg)
 	{
 	case SmartDriverRegister::chopperControl:
-		return SetChopConf(regVal);
+		return SetChopConf(regVal, true);
 
 	case SmartDriverRegister::toff:
 		return SetChopConf((configuredChopConfReg & ~CHOPCONF_TOFF_MASK) | ((regVal << CHOPCONF_TOFF_SHIFT) & CHOPCONF_TOFF_MASK));
@@ -602,10 +602,16 @@ uint32_t TmcDriverState::GetRegister(SmartDriverRegister reg) const
 }
 
 // Set the chopper control register to the settings provided by the user. We allow only the lowest 17 bits to be set.
-bool TmcDriverState::SetChopConf(uint32_t newVal)
+bool TmcDriverState::SetChopConf(uint32_t newVal, bool raw)
 {
 	const uint32_t offTime = (newVal & CHOPCONF_TOFF_MASK) >> CHOPCONF_TOFF_SHIFT;
-	if (offTime == 0 || (offTime == 1 && (newVal & CHOPCONF_TBL_MASK) < (2 << CHOPCONF_TBL_SHIFT)))
+	// TOFF = 0 turns the driver off so it is not allowed unless given via Cnnn parameter.
+	if (!raw && offTime == 0)
+	{
+		return false;
+	}
+	// TOFF = 1 is not allowed if TBL = 0.
+	if (offTime == 1 && (newVal & CHOPCONF_TBL_MASK) < (2 << CHOPCONF_TBL_SHIFT))
 	{
 		return false;
 	}

--- a/src/Movement/StepperDrivers/TMC2660.cpp
+++ b/src/Movement/StepperDrivers/TMC2660.cpp
@@ -210,7 +210,7 @@ public:
 	uint32_t ReadMicrostepPosition() const { return mstepPosition; }
 
 private:
-	bool SetChopConf(uint32_t newVal);
+	bool SetChopConf(uint32_t newVal, bool raw = false);
 
 	void ResetLoadRegisters()
 	{
@@ -419,7 +419,7 @@ bool TmcDriverState::SetRegister(SmartDriverRegister reg, uint32_t regVal)
 	switch(reg)
 	{
 	case SmartDriverRegister::chopperControl:
-		return SetChopConf(regVal);
+		return SetChopConf(regVal, true);
 
 	case SmartDriverRegister::coolStep:
 		registers[SmartEnable] = TMC_REG_SMARTEN | (regVal & 0xFFFF);
@@ -482,12 +482,16 @@ uint32_t TmcDriverState::GetRegister(SmartDriverRegister reg) const
 }
 
 // Check the new chopper control register, update it and return true if it is legal
-bool TmcDriverState::SetChopConf(uint32_t newVal)
+bool TmcDriverState::SetChopConf(uint32_t newVal, bool raw)
 {
-	// TOFF = 0 turns the driver off so it is not allowed.
-	// TOFF = 1 is not allowed if TBL = 0.
 	const uint32_t toff = (newVal & TMC_CHOPCONF_TOFF_MASK) >> TMC_CHOPCONF_TOFF_SHIFT;
-	if (toff == 0 || (toff == 1 && ((newVal & TMC_CHOPCONF_TBL_MASK) == 0)))
+	// TOFF = 0 turns the driver off so it is not allowed unless given via Cnnn parameter.
+	if (!raw && toff == 0)
+	{
+		return false;
+	}
+	// TOFF = 1 is not allowed if TBL = 0.
+	if (toff == 1 && ((newVal & TMC_CHOPCONF_TBL_MASK) == 0))
 	{
 		return false;
 	}

--- a/src/Movement/StepperDrivers/TMC51xx.cpp
+++ b/src/Movement/StepperDrivers/TMC51xx.cpp
@@ -290,7 +290,7 @@ public:
 	void TransferFailed();
 
 private:
-	bool SetChopConf(uint32_t newVal);
+	bool SetChopConf(uint32_t newVal, bool raw = false);
 	void UpdateRegister(size_t regIndex, uint32_t regVal);
 	void UpdateChopConfRegister();							// calculate the chopper control register and flag it for sending
 	void UpdateCurrent();
@@ -485,7 +485,7 @@ bool TmcDriverState::SetRegister(SmartDriverRegister reg, uint32_t regVal)
 	switch(reg)
 	{
 	case SmartDriverRegister::chopperControl:
-		return SetChopConf(regVal);
+		return SetChopConf(regVal, true);
 
 	case SmartDriverRegister::toff:
 		return SetChopConf((configuredChopConfReg & ~CHOPCONF_TOFF_MASK) | ((regVal << CHOPCONF_TOFF_SHIFT) & CHOPCONF_TOFF_MASK));
@@ -552,10 +552,16 @@ uint32_t TmcDriverState::GetRegister(SmartDriverRegister reg) const
 }
 
 // Set the chopper control register to the settings provided by the user. We allow only the lowest 17 bits to be set.
-bool TmcDriverState::SetChopConf(uint32_t newVal)
+bool TmcDriverState::SetChopConf(uint32_t newVal, bool raw)
 {
 	const uint32_t offTime = (newVal & CHOPCONF_TOFF_MASK) >> CHOPCONF_TOFF_SHIFT;
-	if (offTime == 0 || (offTime == 1 && (newVal & CHOPCONF_TBL_MASK) < (2 << CHOPCONF_TBL_SHIFT)))
+	// TOFF = 0 turns the driver off so it is not allowed unless given via Cnnn parameter.
+	if (!raw && offTime == 0)
+	{
+		return false;
+	}
+	// TOFF = 1 is not allowed if TBL = 0.
+	if (offTime == 1 && (newVal & CHOPCONF_TBL_MASK) < (2 << CHOPCONF_TBL_SHIFT))
 	{
 		return false;
 	}


### PR DESCRIPTION
As discussed in https://forum.duet3d.com/topic/8829/re-enable-toff-0-for-m569-cnnn