### PR TITLE
Enhance M140, M141 and T with heater state controls

### DIFF
--- a/src/Tools/Tool.cpp
+++ b/src/Tools/Tool.cpp
@@ -594,6 +594,25 @@ void Tool::SetToolHeaterStandbyTemperature(size_t heaterNumber, float temp) THRO
 	}
 }
 
+void Tool::SetToolHeaterStatus(size_t heaterNumber, int status) noexcept
+{
+	if (heaterNumber < heaterCount)
+	{
+		switch(status) {
+		case (int)HeaterStatus::off:
+			reprap.GetHeat().SwitchOff(heaters[heaterNumber]);
+			break;
+		case (int)HeaterStatus::standby:
+			reprap.GetHeat().Standby(heaters[heaterNumber], this);
+			break;
+		case (int)HeaterStatus::active:
+			String<1> dummy;
+			reprap.GetHeat().Activate(heaters[heaterNumber], dummy.GetRef());
+			break;
+		}
+	}
+}
+
 void Tool::IterateExtruders(std::function<void(unsigned int)> f) const noexcept
 {
 	for (size_t i = 0; i < driveCount; ++i)

--- a/src/Tools/Tool.h
+++ b/src/Tools/Tool.h
@@ -96,6 +96,7 @@ public:
 	void SetToolHeaterActiveTemperature(size_t heaterNumber, float temp) THROWS(GCodeException);
 	void SetToolHeaterStandbyTemperature(size_t heaterNumber, float temp) THROWS(GCodeException);
 	GCodeResult SetFirmwareRetraction(GCodeBuffer& gb, const StringRef& reply, OutputBuffer*& outBuf) THROWS(GCodeException);
+	void SetToolHeaterStatus(size_t heaterNumber, int status) noexcept;
 
 	bool HasTemperatureFault() const noexcept { return heaterFault; }
 


### PR DESCRIPTION
* M140, M141
  Added "Q" parameter that takes the following values:
    0: Turn heater off
    1: Set heater to standby
    2: Set heater on
  The default is "2" which mimics the existing the behavior
  of turning the heater on.

  Examples:
  M140 H0 S70 R55 Q0  ; Set the active and standby temperatures
                      ; for H0 but do NOT actually turn the heater on.

  M140 H0 Q1          ; Set the heater state to standby.

  M140 H0 Q0          ; Turn the bed heater OFF without changing
                      ; the previously set active and standby temps.

  M140 H0 Q2          ; Turn the heater on using the previously set
                      ; "active" temperature.

* T
  Added "H" and "Q" parameters
  "H" selects which tool heater to apply the state to.
      The numbers start at 0 so H0 refers to the first heater
      assigned to the tool, not the global heater number.
  "Q" sets the heater state as above.
  Using "H" does NOT actually select the tool, it
  only sets the heater state set by "Q"

  Example:
  M563 S"FilamentA" P0 D0 H1   ; Define Tool 0 with H1
  M563 S"FilamentB" P1 D0 H2:3 ; Define Tool 1 with H2 and H3

  G10 P0 R160 S225        ; Set their active and standby temps.
  ...
  T0 H0 Q1                ; Set tool 0's heater to standby.
  T1 H0 Q1                ; Set tool 1's first heater to standby.
  T1 H1 Q2                ; Set tool 1's second heater to active.
                          ; Neither tool is actually selected.