### PR TITLE
Extended logging

### DIFF
--- a/src/CAN/ExpansionManager.h
+++ b/src/CAN/ExpansionManager.h
@@ -49,12 +49,12 @@ public:
 
 	void EmergencyStop() noexcept;
 
+	const ExpansionBoardData& FindIndexedBoard(unsigned int index) const noexcept;
 protected:
 	DECLARE_OBJECT_MODEL
 
 private:
 	void UpdateBoardState(CanAddress address, BoardState newState) noexcept;
-	const ExpansionBoardData& FindIndexedBoard(unsigned int index) const noexcept;
 
 	unsigned int numExpansionBoards;
 	unsigned int numBoardsFlashing;

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -235,6 +235,7 @@ constexpr size_t MachineNameLength = StringLength50;
 constexpr size_t RepRapPasswordLength = StringLength20;
 constexpr size_t MediumStringLength = MaxFilenameLength;
 constexpr size_t StringBufferLength = StringLength256;	// Length of the string buffer used by the expression parser
+constexpr size_t StringLengthLoggedCommand = StringLength100;	// Length of a string buffer for a command to be logged
 
 #if SAM4E || SAM4S || SAME70 || SAME5x || defined(ESP_NETWORKING)
 // Increased GCODE_LENGTH on the SAM4 because M587 and M589 commands on the Duet WiFi can get very long and GCode meta commands can get even longer

--- a/src/GCodes/GCodes.cpp
+++ b/src/GCodes/GCodes.cpp
@@ -3230,7 +3230,7 @@ GCodeResult GCodes::SetOrReportOffsets(GCodeBuffer &gb, const StringRef& reply) 
 	}
 	else
 	{
-		String<GCODE_LENGTH> scratch;
+		String<StringLengthLoggedCommand> scratch;
 		gb.AppendFullCommand(scratch.GetRef());
 		platform.Message(MessageType::LogInfo, scratch.c_str());
 	}

--- a/src/GCodes/GCodes2.cpp
+++ b/src/GCodes/GCodes2.cpp
@@ -1673,10 +1673,6 @@ bool GCodes::HandleMcode(GCodeBuffer& gb, const StringRef& reply) THROWS(GCodeEx
 				gb.GetQuotedString(message.GetRef());
 
 				MessageType type = GenericMessage;
-#if 0 && HAS_MASS_STORAGE
-				// Send all M118 to debug log
-				type = AddLogDebug(type);
-#endif
 				bool seenP = false;
 				if (gb.Seen('P'))
 				{

--- a/src/GCodes/GCodes3.cpp
+++ b/src/GCodes/GCodes3.cpp
@@ -184,6 +184,9 @@ GCodeResult GCodes::GetSetWorkplaceCoordinates(GCodeBuffer& gb, const StringRef&
 		if (seen)
 		{
 			reprap.MoveUpdated();
+			String<GCODE_LENGTH> scratch;
+			gb.AppendFullCommand(scratch.GetRef());
+			platform.Message(MessageType::LogInfo, scratch.c_str());
 		}
 		else
 		{

--- a/src/GCodes/GCodes3.cpp
+++ b/src/GCodes/GCodes3.cpp
@@ -184,7 +184,7 @@ GCodeResult GCodes::GetSetWorkplaceCoordinates(GCodeBuffer& gb, const StringRef&
 		if (seen)
 		{
 			reprap.MoveUpdated();
-			String<GCODE_LENGTH> scratch;
+			String<StringLengthLoggedCommand> scratch;
 			gb.AppendFullCommand(scratch.GetRef());
 			platform.Message(MessageType::LogInfo, scratch.c_str());
 		}

--- a/src/GCodes/GCodes4.cpp
+++ b/src/GCodes/GCodes4.cpp
@@ -391,7 +391,7 @@ void GCodes::RunStateMachine(GCodeBuffer& gb, const StringRef& reply) noexcept
 			{
 				reply.catf(" %c%.1f", axisLetters[axis], (double)pauseRestorePoint.moveCoords[axis]);
 			}
-			platform.MessageF(LogMessage, "%s\n", reply.c_str());
+			platform.MessageF(LogWarn, "%s\n", reply.c_str());
 			gb.SetState(GCodeState::normal);
 		}
 		break;
@@ -441,7 +441,7 @@ void GCodes::RunStateMachine(GCodeBuffer& gb, const StringRef& reply) noexcept
 			restartInitialUserY = pauseRestorePoint.initialUserY;
 			isPaused = false;
 			reply.copy("Printing resumed");
-			platform.Message(LogMessage, "Printing resumed\n");
+			platform.Message(LogWarn, "Printing resumed\n");
 			gb.SetState(GCodeState::normal);
 		}
 		break;
@@ -789,7 +789,7 @@ void GCodes::RunStateMachine(GCodeBuffer& gb, const StringRef& reply) noexcept
 		}
 		if (stateMachineResult == GCodeResult::ok)
 		{
-			reprap.GetPlatform().MessageF(LogMessage, "%s\n", reply.c_str());
+			reprap.GetPlatform().MessageF(LogWarn, "%s\n", reply.c_str());
 		}
 		gb.SetState(GCodeState::normal);
 		break;

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -12,6 +12,7 @@
 #include "OutputMemory.h"
 #include "RepRap.h"
 #include "Platform.h"
+#include "Version.h"
 
 // Simple lock class that sets a variable true when it is created and makes sure it gets set false when it falls out of scope
 class Lock
@@ -24,13 +25,13 @@ private:
 	bool& b;
 };
 
-Logger::Logger() noexcept : logFile(), lastFlushTime(0), lastFlushFileSize(0), dirty(false), inLogger(false)
+Logger::Logger(LogLevel logLvl) noexcept : logFile(), lastFlushTime(0), lastFlushFileSize(0), dirty(false), inLogger(false), logLevel(logLvl)
 {
 }
 
 void Logger::Start(time_t time, const StringRef& filename) noexcept
 {
-	if (!inLogger)
+	if (!inLogger && logLevel > LogLevel::OFF)
 	{
 		Lock loggerLock(inLogger);
 		FileStore * const f = reprap.GetPlatform().OpenSysFile(filename.c_str(), OpenMode::append);
@@ -40,10 +41,35 @@ void Logger::Start(time_t time, const StringRef& filename) noexcept
 			lastFlushFileSize = logFile.Length();
 			logFile.Seek(lastFlushFileSize);
 			logFileName.copy(filename.c_str());
-			InternalLogMessage(time, "Event logging started\n");
+			String<40> startMessage;
+			startMessage.printf("Event logging started at level %s\n", logLevel.ToString());
+			InternalLogMessage(time, startMessage.c_str(), MessageLogLevel::INFO);
+			LogFirmwareInfo(time);
 			reprap.StateUpdated();
 		}
 	}
+}
+
+// TODO: Move this to a more sensible location
+void Logger::LogFirmwareInfo(time_t time) noexcept
+{
+	const size_t versionStringLength = 80
+#if 0 && SUPPORT_CAN_EXPANSION // TODO
+			+ reprap.GetExpansion().GetNumExpansionBoards() + 1 * 80
+#endif
+			;
+	char buffer[versionStringLength];
+	StringRef firmwareInfo(buffer, ARRAY_SIZE(buffer));// This is huge but should accomodate for around 20 boards
+	firmwareInfo.printf("Running: %s: %s (%s)", reprap.GetPlatform().GetElectronicsString(), VERSION, DATE);
+
+#if 0 && SUPPORT_CAN_EXPANSION // TODO
+	for (size_t i = 1; i < reprap.GetExpansion().GetNumExpansionBoards() + 1; ++i)
+	{
+		auto expansionBoardData = reprap.GetExpansion().FindIndexedBoard(i);
+		firmwareInfo.catf(" - %s", expansionBoardData.typeName);
+	}
+#endif
+	InternalLogMessage(time, firmwareInfo.c_str(), MessageLogLevel::INFO);
 }
 
 void Logger::Stop(time_t time) noexcept
@@ -51,27 +77,58 @@ void Logger::Stop(time_t time) noexcept
 	if (logFile.IsLive() && !inLogger)
 	{
 		Lock loggerLock(inLogger);
-		InternalLogMessage(time, "Event logging stopped\n");
+		InternalLogMessage(time, "Event logging stopped\n", MessageLogLevel::INFO);
 		logFile.Close();
 		reprap.StateUpdated();
 	}
 }
 
-void Logger::LogMessage(time_t time, const char *message) noexcept
+// This will not start the logger if it is currently stopped
+void Logger::SetLogLevel(LogLevel newLogLevel) noexcept
 {
-	if (logFile.IsLive() && !inLogger)
+	if (logLevel != newLogLevel)
 	{
-		Lock loggerLock(inLogger);
-		InternalLogMessage(time, message);
+		logLevel = newLogLevel;
+		reprap.StateUpdated();
 	}
 }
 
-void Logger::LogMessage(time_t time, OutputBuffer *buf) noexcept
+//bool Logger::IsLoggingEnabledFor(const MessageType mt) const noexcept
+//{
+//	const auto messageLogLevel = GetMessageLogLevel(mt);
+//	return IsLoggingEnabledFor(messageLogLevel);
+//}
+
+void Logger::LogMessage(time_t time, const char *message, MessageType type) noexcept
 {
-	if (logFile.IsLive() && !inLogger)
+
+	if (logFile.IsLive() && !inLogger && !IsEmptyMessage(message))
 	{
+		const auto messageLogLevel = GetMessageLogLevel(type);
+		if (!IsLoggingEnabledFor(messageLogLevel))
+		{
+			return;
+		}
+		Lock loggerLock(inLogger);
+		InternalLogMessage(time, message, messageLogLevel);
+	}
+}
+
+void Logger::LogMessage(time_t time, OutputBuffer *buf, MessageType type) noexcept
+{
+	if (logFile.IsLive() && !inLogger && !IsEmptyMessage(buf->Data()))
+	{
+		const auto messageLogLevel = GetMessageLogLevel(type);
+		if (!IsLoggingEnabledFor(messageLogLevel))
+		{
+			return;
+		}
 		Lock loggerLock(inLogger);
 		bool ok = WriteDateTime(time);
+		if (ok)
+		{
+			ok = WriteLogLevelPrefix(messageLogLevel);
+		}
 		if (ok)
 		{
 			ok = buf->WriteToFile(logFile);
@@ -90,9 +147,13 @@ void Logger::LogMessage(time_t time, OutputBuffer *buf) noexcept
 }
 
 // Version of LogMessage for when we already know we want to proceed and we have already set inLogger
-void Logger::InternalLogMessage(time_t time, const char *message) noexcept
+void Logger::InternalLogMessage(time_t time, const char *message, const MessageLogLevel messageLogLevel) noexcept
 {
 	bool ok = WriteDateTime(time);
+	if (ok)
+	{
+		ok = WriteLogLevelPrefix(messageLogLevel);
+	}
 	if (ok)
 	{
 		const size_t len = strlen(message);
@@ -158,6 +219,14 @@ bool Logger::WriteDateTime(time_t time) noexcept
 		buf.printf("%04u-%02u-%02u %02u:%02u:%02u ",
 						timeInfo.tm_year + 1900, timeInfo.tm_mon + 1, timeInfo.tm_mday, timeInfo.tm_hour, timeInfo.tm_min, timeInfo.tm_sec);
 	}
+	return logFile.Write(buf.c_str());
+}
+
+bool Logger::WriteLogLevelPrefix(MessageLogLevel messageLogLevel) noexcept
+{
+	String<10> bufferSpace;
+	const StringRef buf = bufferSpace.GetRef();
+	buf.printf("[%s] ", messageLogLevel.ToString());
 	return logFile.Write(buf.c_str());
 }
 

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -14,25 +14,44 @@
 
 #include <ctime>
 #include "Storage/FileData.h"
+#include "MessageType.h"
+#include <General/NamedEnum.h>
 
 class OutputBuffer;
+
+NamedEnum(LogLevel, uint8_t, OFF, WARN, INFO, DEBUG);
 
 class Logger
 {
 public:
-	Logger() noexcept;
+	Logger(LogLevel logLvl) noexcept;
 
 	void Start(time_t time, const StringRef& file) noexcept;
 	void Stop(time_t time) noexcept;
-	void LogMessage(time_t time, const char *message) noexcept;
-	void LogMessage(time_t time, OutputBuffer *buf) noexcept;
+	void LogMessage(time_t time, const char *message, MessageType type) noexcept;
+	void LogMessage(time_t time, OutputBuffer *buf, MessageType type) noexcept;
 	void Flush(bool forced) noexcept;
 	bool IsActive() const noexcept { return logFile.IsLive(); }
 	const char *GetFileName() const noexcept { return (IsActive()) ? logFileName.c_str() : nullptr; }
+	LogLevel GetLogLevel() const noexcept { return logLevel; }
+	void SetLogLevel(LogLevel newLogLevel) noexcept;
+//	bool IsLoggingEnabledFor(const MessageType mt) const noexcept;
+//	bool IsWarnEnabled() const noexcept { return logLevel >= LogLevel::WARN; }
+//	bool IsInfoEnabled() const noexcept { return logLevel >= LogLevel::INFO; }
+//	bool IsDebugEnabled() const noexcept { return logLevel >= LogLevel::DEBUG; }
 
 private:
+	NamedEnum(MessageLogLevel, uint8_t, DEBUG, INFO, WARN, OFF);
+	MessageLogLevel GetMessageLogLevel(MessageType mt) const noexcept { return (MessageLogLevel) ((mt & MessageType::LogOff)>>30); }
+
+	static const uint8_t LogEnabledThreshold = 3;
+
 	bool WriteDateTime(time_t time) noexcept;
-	void InternalLogMessage(time_t time, const char *message) noexcept;
+	bool WriteLogLevelPrefix(MessageLogLevel messageLogLevel) noexcept;
+	void InternalLogMessage(time_t time, const char *message, const MessageLogLevel messageLogLevel) noexcept;
+	bool IsLoggingEnabledFor(const MessageLogLevel mll) const noexcept { return (mll < MessageLogLevel::OFF) && (mll.ToBaseType() + logLevel.ToBaseType() >= LogEnabledThreshold); }
+	void LogFirmwareInfo(time_t time) noexcept;
+	bool IsEmptyMessage(const char * message) const noexcept { return message[0] == '\0' || (message[0] == '\n' && message[1] == '\0'); }
 
 	String<MaxFilenameLength> logFileName;
 	FileData logFile;
@@ -40,6 +59,7 @@ private:
 	FilePosition lastFlushFileSize;
 	bool dirty;
 	bool inLogger;
+	LogLevel logLevel;
 };
 
 #endif

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -35,10 +35,12 @@ public:
 	const char *GetFileName() const noexcept { return (IsActive()) ? logFileName.c_str() : nullptr; }
 	LogLevel GetLogLevel() const noexcept { return logLevel; }
 	void SetLogLevel(LogLevel newLogLevel) noexcept;
-//	bool IsLoggingEnabledFor(const MessageType mt) const noexcept;
-//	bool IsWarnEnabled() const noexcept { return logLevel >= LogLevel::WARN; }
-//	bool IsInfoEnabled() const noexcept { return logLevel >= LogLevel::INFO; }
-//	bool IsDebugEnabled() const noexcept { return logLevel >= LogLevel::DEBUG; }
+#if 0 // Currently not needed but might be useful in the future
+	bool IsLoggingEnabledFor(const MessageType mt) const noexcept;
+	bool IsWarnEnabled() const noexcept { return logLevel >= LogLevel::WARN; }
+	bool IsInfoEnabled() const noexcept { return logLevel >= LogLevel::INFO; }
+	bool IsDebugEnabled() const noexcept { return logLevel >= LogLevel::DEBUG; }
+#endif
 
 private:
 	NamedEnum(MessageLogLevel, uint8_t, DEBUG, INFO, WARN, OFF);
@@ -46,8 +48,7 @@ private:
 
 	static const uint8_t LogEnabledThreshold = 3;
 
-	bool WriteDateTime(time_t time) noexcept;
-	bool WriteLogLevelPrefix(MessageLogLevel messageLogLevel) noexcept;
+	bool WriteDateTimeAndLogLevelPrefix(time_t time, MessageLogLevel messageLogLevel) noexcept;
 	void InternalLogMessage(time_t time, const char *message, const MessageLogLevel messageLogLevel) noexcept;
 	bool IsLoggingEnabledFor(const MessageLogLevel mll) const noexcept { return (mll < MessageLogLevel::OFF) && (mll.ToBaseType() + logLevel.ToBaseType() >= LogEnabledThreshold); }
 	void LogFirmwareInfo(time_t time) noexcept;

--- a/src/MessageType.h
+++ b/src/MessageType.h
@@ -15,53 +15,85 @@ enum MessageType : uint32_t
 {
 	// Destinations (bytes 1-2)
 	// Keep the following in sync with the order of GCodeBuffers in the GCodes class
-	HttpMessage = 0x01,					// A message that is to be sent to the web (HTTP)
-	TelnetMessage = 0x02,				// A message that is to be sent to a Telnet client
-	FileMessage = 0x04,					// A message that is to be sent to a file processor
-	UsbMessage = 0x08,					// A message that is to be sent in non-blocking mode to the host via USB
-	AuxMessage  = 0x10,					// A message that is to be sent to an auxiliary device (PanelDue)
-	TriggerMessage = 0x20,				// A message that is to be sent to a trigger processor
-	CodeQueueMessage = 0x40,			// A message that is to be sent to the code queue channel
-	LcdMessage = 0x80,					// A message that is to be sent to the panel
-	SbcMessage = 0x100,					// A message that is to be sent to the SBC
-	DaemonMessage = 0x200,				// A message that is sent to the daemon processor
-	Aux2Message = 0x400,				// A message that is to be sent to the second aux device
-	AutoPauseMessage = 0x800,			// A message that is to be sent to an auto-pause processor
+	HttpMessage =				  0x01,	// A message that is to be sent to the web (HTTP)
+	TelnetMessage =				  0x02,	// A message that is to be sent to a Telnet client
+	FileMessage =				  0x04,	// A message that is to be sent to a file processor
+	UsbMessage =				  0x08,	// A message that is to be sent in non-blocking mode to the host via USB
+	AuxMessage =				  0x10,	// A message that is to be sent to an auxiliary device (PanelDue)
+	TriggerMessage =			  0x20,	// A message that is to be sent to a trigger processor
+	CodeQueueMessage =			  0x40,	// A message that is to be sent to the code queue channel
+	LcdMessage =				  0x80,	// A message that is to be sent to the panel
+	SbcMessage =				 0x100,	// A message that is to be sent to the SBC
+	DaemonMessage =				 0x200,	// A message that is sent to the daemon processor
+	Aux2Message =				 0x400,	// A message that is to be sent to the second aux device
+	AutoPauseMessage =			 0x800,	// A message that is to be sent to an auto-pause processor
 
 	// Special destinations (byte 3)
-    BlockingUsbMessage = 0x10000,		// A message that is to be sent to USB in blocking mode
-    ImmediateAuxMessage = 0x20000,		// A message that is to be sent to LCD in immediate mode
+	BlockingUsbMessage =	   0x10000,	// A message that is to be sent to USB in blocking mode
+	ImmediateAuxMessage =	   0x20000,	// A message that is to be sent to LCD in immediate mode
 
 	// Special indicators (byte 4)
 	// The first two are not processed when calling the version of Platform::Message that takes an OutputBuffer.
-	ErrorMessageFlag = 0x1000000,		// This is an error message
-	WarningMessageFlag = 0x2000000,		// This is a warning message
-	LogMessage = 0x4000000,				// A message to be written to the log file
-	RawMessageFlag = 0x8000000,			// Do not encapsulate this message
-	BinaryCodeReplyFlag = 0x10000000,	// This message comes from a binary G-Code buffer
-	PushFlag = 0x20000000,				// There is more to come; the message has been truncated
+	ErrorMessageFlag =		 0x1000000,	// This is an error message
+	WarningMessageFlag =	 0x2000000,	// This is a warning message
+	RawMessageFlag =		 0x8000000,	// Do not encapsulate this message
+	BinaryCodeReplyFlag =	0x10000000,	// This message comes from a binary G-Code buffer
+	PushFlag =				0x20000000,	// There is more to come; the message has been truncated
+	LogMessageLowBit =		0x40000000,	// Log level consists of two bits this is the low bit
+	LogMessageHighBit =		0x80000000,	// Log level consists of two bits this is the high bit
 
 	// Common combinations
 	NoDestinationMessage = 0,												// A message that is going nowhere
 	DebugMessage = BlockingUsbMessage,										// A debug message to send in blocking mode to USB
 	GenericMessage = UsbMessage | AuxMessage | HttpMessage | TelnetMessage,	// A message that is to be sent to the web, Telnet, USB and panel
-	LoggedGenericMessage = GenericMessage | LogMessage,						// A GenericMessage that is also logged
+	LogOff = LogMessageLowBit | LogMessageHighBit,							// Log level "off (3): do not log this message
+	LogWarn = LogMessageHighBit,											// Log level "warn" (2): all messages of type Error and Warning are logged
+	LogInfo = LogMessageLowBit,												// Log level "info" (1): all messages of level "warn" plus info messages
+	LoggedGenericMessage = GenericMessage | LogWarn,						// A GenericMessage that is also logged
 	DirectAuxMessage = AuxMessage | RawMessageFlag,							// Direct message to PanelDue
- 	ErrorMessage = GenericMessage | LogMessage | ErrorMessageFlag,			// An error message
-	WarningMessage = GenericMessage | LogMessage | WarningMessageFlag,		// A warning message
+	ErrorMessage = GenericMessage | LogWarn | ErrorMessageFlag,				// An error message
+	WarningMessage = GenericMessage | LogWarn | WarningMessageFlag,			// A warning message
 	FirmwareUpdateMessage = UsbMessage | ImmediateAuxMessage,				// A message that conveys progress of a firmware update
 	FirmwareUpdateErrorMessage = FirmwareUpdateMessage | ErrorMessageFlag,	// A message that reports an error during a firmware update
-	NetworkInfoMessage = UsbMessage | AuxMessage | LogMessage			 	// A message that conveys information about the state of the network interface
+	NetworkInfoMessage = UsbMessage | AuxMessage | LogWarn				 	// A message that conveys information about the state of the network interface
 };
+
+inline MessageType AddLogDebug(MessageType mt)
+{
+	// Debug level has no flags set such that any non-flagged message automatically
+	// is part of this log level - force it by removing the existing flags
+	return (MessageType)(mt & ~(LogMessageLowBit | LogMessageHighBit));
+}
+
+inline MessageType AddLogWarn(MessageType mt)
+{
+	// Since increasing log levels have lower numbers we need to delete
+	// any existing log flags first - otherwise this could lead to MessageLogLevel
+	// rising to 3 which is equivalent to OFF
+	return (MessageType)(AddLogDebug(mt) | LogWarn);
+}
+
+inline MessageType AddLogInfo(MessageType mt)
+{
+	// Since increasing log levels have lower numbers we need to delete
+	// any existing log flags first - otherwise this could lead to MessageLogLevel
+	// rising to 3 which is equivalent to OFF
+	return (MessageType)(AddLogDebug(mt) | LogInfo);
+}
+
+inline MessageType RemoveLogging(MessageType mt)
+{
+	return (MessageType)(mt | LogOff);
+}
 
 inline MessageType AddError(MessageType mt)
 {
-	return (MessageType)(mt | ErrorMessageFlag | LogMessage);
+	return AddLogWarn((MessageType)(mt | ErrorMessageFlag));
 }
 
 inline MessageType AddWarning(MessageType mt)
 {
-	return (MessageType)(mt | WarningMessageFlag | LogMessage);
+	return AddLogWarn((MessageType)(mt | WarningMessageFlag));
 }
 
 #endif /* MESSAGETYPE_H_ */

--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -585,7 +585,7 @@ bool HangprinterKinematics::DoAutoCalibration(size_t numFactors, const RandomPro
 	{
 		String<StringLength256> scratchString;
 		scratchString.printf("%s\n", reply.c_str());
-		reprap.GetPlatform().Message(LogMessage, scratchString.c_str());
+		reprap.GetPlatform().Message(LogWarn, scratchString.c_str());
 	}
 
     doneAutoCalibration = true;

--- a/src/Movement/Kinematics/LinearDeltaKinematics.cpp
+++ b/src/Movement/Kinematics/LinearDeltaKinematics.cpp
@@ -629,7 +629,7 @@ bool LinearDeltaKinematics::DoAutoCalibration(size_t numFactors, const RandomPro
 	{
 		String<StringLength256> scratchString;
 		scratchString.printf("%s\n", reply.c_str());
-		reprap.GetPlatform().Message(LogMessage, scratchString.c_str());
+		reprap.GetPlatform().Message(LogWarn, scratchString.c_str());
 	}
 
     doneAutoCalibration = true;

--- a/src/Movement/Kinematics/ZLeadscrewKinematics.cpp
+++ b/src/Movement/Kinematics/ZLeadscrewKinematics.cpp
@@ -408,7 +408,7 @@ bool ZLeadscrewKinematics::DoAutoCalibration(size_t numFactors, const RandomProb
 			}
 		}
 	}
-	reprap.GetPlatform().MessageF(LogMessage, "%s\n", reply.c_str());
+	reprap.GetPlatform().MessageF(LogWarn, "%s\n", reply.c_str());
 	return failed;
 }
 

--- a/src/Networking/HttpResponder.cpp
+++ b/src/Networking/HttpResponder.cpp
@@ -462,14 +462,14 @@ bool HttpResponder::GetJsonResponse(const char* request, OutputBuffer *&response
 			{
 				// Wrong password
 				response->copy("{\"err\":1}");
-				reprap.GetPlatform().MessageF(LogMessage, "HTTP client %s attempted login with incorrect password\n", IP4String(GetRemoteIP()).c_str());
+				reprap.GetPlatform().MessageF(LogWarn, "HTTP client %s attempted login with incorrect password\n", IP4String(GetRemoteIP()).c_str());
 				return true;
 			}
 			if (!Authenticate())
 			{
 				// No more HTTP sessions available
 				response->copy("{\"err\":2}");
-				reprap.GetPlatform().MessageF(LogMessage, "HTTP client %s attempted login but no more sessions available\n", IP4String(GetRemoteIP()).c_str());
+				reprap.GetPlatform().MessageF(LogWarn, "HTTP client %s attempted login but no more sessions available\n", IP4String(GetRemoteIP()).c_str());
 				return true;
 			}
 		}
@@ -477,7 +477,7 @@ bool HttpResponder::GetJsonResponse(const char* request, OutputBuffer *&response
 		// Client has been logged in
 		response->printf("{\"err\":0,\"sessionTimeout\":%" PRIu32 ",\"boardType\":\"%s\",\"apiLevel\":%u}",
 							HttpSessionTimeout, GetPlatform().GetBoardString(), ApiLevel);
-		reprap.GetPlatform().MessageF(LogMessage, "HTTP client %s login succeeded\n", IP4String(GetRemoteIP()).c_str());
+		reprap.GetPlatform().MessageF(LogWarn, "HTTP client %s login succeeded\n", IP4String(GetRemoteIP()).c_str());
 
 		// See if we can update the current RTC date and time
 		const char* const timeString = GetKeyValue("time");
@@ -499,7 +499,7 @@ bool HttpResponder::GetJsonResponse(const char* request, OutputBuffer *&response
 	else if (StringEqualsIgnoreCase(request, "disconnect"))
 	{
 		response->printf("{\"err\":%d}", (RemoveAuthentication()) ? 0 : 1);
-		reprap.GetPlatform().MessageF(LogMessage, "HTTP client %s disconnected\n", IP4String(GetRemoteIP()).c_str());
+		reprap.GetPlatform().MessageF(LogWarn, "HTTP client %s disconnected\n", IP4String(GetRemoteIP()).c_str());
 	}
 	else if (StringEqualsIgnoreCase(request, "status"))
 	{
@@ -1081,7 +1081,7 @@ void HttpResponder::ProcessMessage() noexcept
 	if (reprap.Debug(moduleWebserver))
 	{
 		Platform& p = GetPlatform();
-		p.MessageF(UsbMessage, "HTTP req, command words {");
+		p.Message(UsbMessage, "HTTP req, command words {");
 		for (size_t i = 0; i < numCommandWords; ++i)
 		{
 			p.MessageF(UsbMessage, " %s", commandWords[i]);

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -1725,14 +1725,14 @@ void Platform::Diagnostics(MessageType mtype) noexcept
 	MessageF(mtype, "Last reset %02d:%02d:%02d ago, cause: ",
 			 (unsigned int)(now/3600), (unsigned int)((now % 3600)/60), (unsigned int)(now % 60));
 
-	if (LPC_SYSCTL->RSID & RSID_POR) { MessageF(mtype, "[power up]"); }
-	if (LPC_SYSCTL->RSID & RSID_EXTR) { MessageF(mtype, "[reset button]"); }
-	if (LPC_SYSCTL->RSID & RSID_WDTR) { MessageF(mtype, "[watchdog]"); }
-	if (LPC_SYSCTL->RSID & RSID_BODR) { MessageF(mtype, "[brownout]"); }
-	if (LPC_SYSCTL->RSID & RSID_SYSRESET) { MessageF(mtype, "[software]"); }
-	if (LPC_SYSCTL->RSID & RSID_LOCKUP) { MessageF(mtype, "[lockup]"); }
+	if (LPC_SYSCTL->RSID & RSID_POR) { Message(mtype, "[power up]"); }
+	if (LPC_SYSCTL->RSID & RSID_EXTR) { Message(mtype, "[reset button]"); }
+	if (LPC_SYSCTL->RSID & RSID_WDTR) { Message(mtype, "[watchdog]"); }
+	if (LPC_SYSCTL->RSID & RSID_BODR) { Message(mtype, "[brownout]"); }
+	if (LPC_SYSCTL->RSID & RSID_SYSRESET) { Message(mtype, "[software]"); }
+	if (LPC_SYSCTL->RSID & RSID_LOCKUP) { Message(mtype, "[lockup]"); }
 
-	MessageF(mtype, "\n");
+	Message(mtype, "\n");
 #else
 	const char* resetReasons[8] = { "power up", "backup", "watchdog", "software",
 # ifdef DUET_NG
@@ -3082,9 +3082,9 @@ void Platform::RawMessage(MessageType type, const char *message) noexcept
 {
 #if HAS_MASS_STORAGE
 	// Deal with logging
-	if ((type & LogMessage) != 0 && logger != nullptr)
+	if (logger != nullptr)
 	{
-		logger->LogMessage(realTime, message);
+		logger->LogMessage(realTime, message, type);
 	}
 #endif
 
@@ -3163,9 +3163,9 @@ void Platform::Message(const MessageType type, OutputBuffer *buffer) noexcept
 {
 #if HAS_MASS_STORAGE
 	// First deal with logging because it doesn't hang on to the buffer
-	if ((type & LogMessage) != 0 && logger != nullptr)
+	if (logger != nullptr)
 	{
-		logger->LogMessage(realTime, buffer);
+		logger->LogMessage(realTime, buffer, type);
 	}
 #endif
 
@@ -3321,6 +3321,8 @@ void Platform::SendAlert(MessageType mt, const char *message, const char *title,
 		reprap.SetAlert(message, title, sParam, tParam, controls);		// make the RepRap class cache this message until it's picked up by the HTTP clients and/or PanelDue
 	}
 
+	MessageF(MessageType::LogInfo, "M291: - %s - %s", (strlen(title) > 0 ? title : "[no title]"), message);
+
 	mt = (MessageType)(mt & (UsbMessage | TelnetMessage));
 	if (mt != 0)
 	{
@@ -3348,16 +3350,17 @@ GCodeResult Platform::ConfigureLogging(GCodeBuffer& gb, const StringRef& reply) 
 	if (gb.Seen('S'))
 	{
 		StopLogging();
-		if (gb.GetIValue() > 0)
+		const auto logLevel = (LogLevel) gb.GetLimitedUIValue('S', LogLevel::NumValues, LogLevel::OFF);
+		if (logLevel > LogLevel::OFF)
 		{
 			// Start logging
 			if (logger == nullptr)
 			{
-				logger = new Logger();
+				logger = new Logger(logLevel);
 			}
 			else
 			{
-				StopLogging();
+				logger->SetLogLevel(logLevel);
 			}
 
 			char buf[MaxFilenameLength + 1];
@@ -3375,7 +3378,15 @@ GCodeResult Platform::ConfigureLogging(GCodeBuffer& gb, const StringRef& reply) 
 	}
 	else
 	{
-		reply.printf("Event logging is %s", (logger != nullptr && logger->IsActive()) ? "enabled" : "disabled");
+		if (logger == nullptr || !logger->IsActive())
+		{
+			reply.copy("Event logging is disabled");
+		}
+		else
+		{
+			const auto logLevel = logger->GetLogLevel();
+			reply.printf("Event logging is enabled at log level %s", logLevel.ToString());
+		}
 	}
 	return GCodeResult::ok;
 }
@@ -3384,6 +3395,11 @@ GCodeResult Platform::ConfigureLogging(GCodeBuffer& gb, const StringRef& reply) 
 const char *Platform::GetLogFileName() const noexcept
 {
 	return (logger == nullptr) ? nullptr : logger->GetFileName();
+}
+
+const char *Platform::GetLogLevel() const noexcept
+{
+	return (logger == nullptr) ? nullptr : logger->GetLogLevel().ToString();
 }
 
 #endif
@@ -3423,7 +3439,7 @@ void Platform::AtxPowerOff(bool defer) noexcept
 #if HAS_MASS_STORAGE
 		if (logger != nullptr)
 		{
-			logger->LogMessage(realTime, "Power off commanded");
+			logger->LogMessage(realTime, "Power off commanded", LogWarn);
 			logger->Flush(true);
 			// We don't call logger->Stop() here because we don't know whether turning off the power will work
 		}
@@ -4272,7 +4288,7 @@ bool Platform::SetDateTime(time_t time) noexcept
 
 		// Write a log message, giving the time since power up in same format as the logger does
 		const uint32_t timeSincePowerUp = (uint32_t)(millis64()/1000u);
-		MessageF(LogMessage, "Date and time set at power up + %02" PRIu32 ":%02" PRIu32 ":%02" PRIu32 "\n", timeSincePowerUp/3600u, (timeSincePowerUp % 3600u)/60u, timeSincePowerUp % 60u);
+		MessageF(LogWarn, "Date and time set at power up + %02" PRIu32 ":%02" PRIu32 ":%02" PRIu32 "\n", timeSincePowerUp/3600u, (timeSincePowerUp % 3600u)/60u, timeSincePowerUp % 60u);
 		timeLastUpdatedMillis = millis();
 	}
 	return ok;

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -3401,10 +3401,11 @@ const char *Platform::GetLogFileName() const noexcept
 
 const char *Platform::GetLogLevel() const noexcept
 {
+	static const LogLevel off = LogLevel::OFF;	// need to have an instance otherwise it will fail .ToString() below
 #if HAS_MASS_STORAGE
-	return (logger == nullptr) ? nullptr : logger->GetLogLevel().ToString();
+	return (logger == nullptr) ? off.ToString() : logger->GetLogLevel().ToString();
 #else
-	return LogLevel::OFF.ToString();
+	return off.ToString();
 #endif
 }
 

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -3397,12 +3397,16 @@ const char *Platform::GetLogFileName() const noexcept
 	return (logger == nullptr) ? nullptr : logger->GetFileName();
 }
 
+#endif
+
 const char *Platform::GetLogLevel() const noexcept
 {
+#if HAS_MASS_STORAGE
 	return (logger == nullptr) ? nullptr : logger->GetLogLevel().ToString();
-}
-
+#else
+	return LogLevel::OFF.ToString();
 #endif
+}
 
 // This is called from EmergencyStop. It closes the log file and stops logging.
 void Platform::StopLogging() noexcept

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -562,6 +562,7 @@ public:
 	// Logging support
 	GCodeResult ConfigureLogging(GCodeBuffer& gb, const StringRef& reply) THROWS(GCodeException);
 	const char *GetLogFileName() const noexcept;
+	const char *GetLogLevel() const noexcept;
 #endif
 
 	// Ancillary PWM

--- a/src/RepRap.cpp
+++ b/src/RepRap.cpp
@@ -314,11 +314,10 @@ constexpr ObjectModelTableEntry RepRap::objectModelTable[] =
 #endif
 #if HAS_MASS_STORAGE
 	{ "logFile",				OBJECT_MODEL_FUNC(self->platform->GetLogFileName()),					ObjectModelEntryFlags::none },
-	{ "logLevel",				OBJECT_MODEL_FUNC(self->platform->GetLogLevel()),						ObjectModelEntryFlags::none },
 #else
 	{ "logFile",				OBJECT_MODEL_FUNC_NOSELF(nullptr),										ObjectModelEntryFlags::none },
-	{ "logLevel",				OBJECT_MODEL_FUNC_NOSELF(nullptr),										ObjectModelEntryFlags::none },
 #endif
+	{ "logLevel",				OBJECT_MODEL_FUNC(self->platform->GetLogLevel()),						ObjectModelEntryFlags::none },
 	{ "machineMode",			OBJECT_MODEL_FUNC(self->gCodes->GetMachineModeString()),				ObjectModelEntryFlags::none },
 	{ "messageBox",				OBJECT_MODEL_FUNC_IF(self->mbox.active, self, 5),						ObjectModelEntryFlags::none },
 	{ "msUpTime",				OBJECT_MODEL_FUNC_NOSELF((int32_t)(context.GetStartMillis() % 1000u)),	ObjectModelEntryFlags::live },

--- a/src/RepRap.cpp
+++ b/src/RepRap.cpp
@@ -314,8 +314,10 @@ constexpr ObjectModelTableEntry RepRap::objectModelTable[] =
 #endif
 #if HAS_MASS_STORAGE
 	{ "logFile",				OBJECT_MODEL_FUNC(self->platform->GetLogFileName()),					ObjectModelEntryFlags::none },
+	{ "logLevel",				OBJECT_MODEL_FUNC(self->platform->GetLogLevel()),						ObjectModelEntryFlags::none },
 #else
 	{ "logFile",				OBJECT_MODEL_FUNC_NOSELF(nullptr),										ObjectModelEntryFlags::none },
+	{ "logLevel",				OBJECT_MODEL_FUNC_NOSELF(nullptr),										ObjectModelEntryFlags::none },
 #endif
 	{ "machineMode",			OBJECT_MODEL_FUNC(self->gCodes->GetMachineModeString()),				ObjectModelEntryFlags::none },
 	{ "messageBox",				OBJECT_MODEL_FUNC_IF(self->mbox.active, self, 5),						ObjectModelEntryFlags::none },
@@ -380,7 +382,7 @@ constexpr uint8_t RepRap::objectModelTableDescriptor[] =
 	0,																		// directories
 #endif
 	25,																		// limits
-	15 + HAS_VOLTAGE_MONITOR + SUPPORT_LASER,								// state
+	16 + HAS_VOLTAGE_MONITOR + SUPPORT_LASER,								// state
 	2,																		// state.beep
 	6,																		// state.messageBox
 	11 + HAS_NETWORKING + SUPPORT_SCANNER + 2 * HAS_MASS_STORAGE			// seqs
@@ -2414,6 +2416,7 @@ void RepRap::SetMessage(const char *msg) noexcept
 	{
 		platform->SendPanelDueMessage(0, msg);
 	}
+	platform->Message(MessageType::LogInfo, msg);
 }
 
 // Display a message box on the web interface
@@ -2711,7 +2714,7 @@ void RepRap::UpdateFirmware() noexcept
 	FileStore * const iapFile = platform->OpenFile(DEFAULT_SYS_DIR, IAP_UPDATE_FILE, OpenMode::read);
 	if (iapFile == nullptr)
 	{
-		platform->MessageF(FirmwareUpdateMessage, "IAP file '" IAP_UPDATE_FILE "' not found\n");
+		platform->Message(FirmwareUpdateMessage, "IAP file '" IAP_UPDATE_FILE "' not found\n");
 		return;
 	}
 

--- a/src/Tasks.cpp
+++ b/src/Tasks.cpp
@@ -295,7 +295,7 @@ void Tasks::Diagnostics(MessageType mtype) noexcept
 			p.MessageF(mtype, " %s(%s)", m->GetName(), pcTaskGetName(holder->GetFreeRTOSHandle()));
 		}
 	}
-	p.MessageF(mtype, "\n");
+	p.Message(mtype, "\n");
 }
 
 TaskHandle Tasks::GetMainTask() noexcept


### PR DESCRIPTION
* Extend log levels from only 0 and 1 to 0 to 3
* Add log level to the object model as `state.logLevel`
* Use the two top bits in `MessageType` to represent log levels
* Add `Lnn` parameter to `M118` to have the message logged at the given level
* Add logging for G10, M291, M292
* Add current version to start of logging
* Make all non-flagged messages being part of log level DEBUG
