### PR TITLE
docs: fix simple typo, chaged -> changed

### DIFF
--- a/src/Networking/W5500Ethernet/Wiznet/Internet/DHCP/dhcp.cpp
+++ b/src/Networking/W5500Ethernet/Wiznet/Internet/DHCP/dhcp.cpp
@@ -270,7 +270,7 @@ void default_ip_assign(void)
 	setGAR (DHCP_allocated_gw);
 }
 
-/* The default handler of ip chaged */
+/* The default handler of ip changed */
 void default_ip_update(void)
 {
 	/* WIZchip Software Reset */
@@ -280,7 +280,7 @@ void default_ip_update(void)
 	setSHAR(DHCP_CHADDR);
 }
 
-/* The default handler of ip chaged */
+/* The default handler of ip changed */
 void default_ip_conflict(void)
 {
 	// WIZchip Software Reset


### PR DESCRIPTION
There is a small typo in src/Networking/W5500Ethernet/Wiznet/Internet/DHCP/dhcp.cpp.

Should read `changed` rather than `chaged`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md