### PR TITLE
Feature / Configurable Grace Period for Starting into Moves

### DIFF
--- a/src/Movement/DDARing.cpp
+++ b/src/Movement/DDARing.cpp
@@ -96,13 +96,11 @@ void DDARing::Exit() noexcept
 GCodeResult DDARing::ConfigureMovementQueue(GCodeBuffer& gb, const StringRef& reply) noexcept
 {
 	bool seen = false;
-	bool seenR = false;
 	uint32_t numDdasWanted = 0, numDMsWanted = 0;
-	uint32_t gracePeriodWanted = 0;
 	gb.TryGetUIValue('P', numDdasWanted, seen);
 	gb.TryGetUIValue('S', numDMsWanted, seen);
-	gb.TryGetUIValue('R', gracePeriodWanted, seenR);
-	if (seen || seenR)
+	gb.TryGetUIValue('R', gracePeriod, seen);
+	if (seen)
 	{
 		if (!reprap.GetGCodes().LockMovementAndWaitForStandstill(gb))
 		{
@@ -143,14 +141,10 @@ GCodeResult DDARing::ConfigureMovementQueue(GCodeBuffer& gb, const StringRef& re
 			// Allocate the extra DMs
 			DriveMovement::InitialAllocate(numDMsWanted);		// this will only create any extra ones wanted
 		}
-		if (seenR)
-		{
-			gracePeriod = gracePeriodWanted;
-		}
 	}
 	else
 	{
-		reply.printf("DDAs %u, DMs %u, GracePeriod %lu", numDdasInRing, DriveMovement::NumCreated(), (unsigned long)gracePeriod);
+		reply.printf("DDAs %u, DMs %u, GracePeriod %" PRIu32, numDdasInRing, DriveMovement::NumCreated(), gracePeriod);
 	}
 	return GCodeResult::ok;
 }

--- a/src/Movement/DDARing.h
+++ b/src/Movement/DDARing.h
@@ -31,6 +31,7 @@ public:
 
 	void Spin(uint8_t simulationMode, bool shouldStartMove) noexcept SPEED_CRITICAL;	// Try to process moves in the ring
 	bool IsIdle() const noexcept;														// Return true if this DDA ring is idle
+	uint32_t GetGracePeriod() const noexcept;											// Return the minimum idle time, before we should start a move. Better to have a few moves in the queue so that we can do lookahead
 
 	float PushBabyStepping(size_t axis, float amount) noexcept;							// Try to push some babystepping through the lookahead queue, returning the amount pushed
 
@@ -106,6 +107,7 @@ private:
 	volatile int32_t liveEndPoints[MaxAxesPlusExtruders];						// The XYZ endpoints of the last completed move in motor coordinates
 
 	unsigned int numDdasInRing;
+	uint32_t gracePeriod;														// The minimum idle time, before we should start a move. Better to have a few moves in the queue so that we can do lookahead
 
 	uint32_t scheduledMoves;													// Move counters for the code queue
 	volatile uint32_t completedMoves;											// This one is modified by an ISR, hence volatile

--- a/src/Movement/Move.cpp
+++ b/src/Movement/Move.cpp
@@ -305,8 +305,7 @@ void Move::Spin() noexcept
 	}
 
 	// let the DDA ring process moves. Better to have a few moves in the queue so that we can do lookahead, hence the test on idleCount and idleTime.
-	const uint32_t idleTime = millis() - idleStartTime;
-	mainDDARing.Spin(simulationMode, idleCount > 10 && idleTime >= mainDDARing.GetGracePeriod());
+	mainDDARing.Spin(simulationMode, idleCount > 10 && millis() - idleStartTime >= mainDDARing.GetGracePeriod());
 
 #if SUPPORT_ASYNC_MOVES
 	if (auxMoveAvailable && auxDDARing.CanAddMove())

--- a/src/Movement/Move.h
+++ b/src/Movement/Move.h
@@ -250,6 +250,7 @@ private:
 
 	unsigned int jerkPolicy;							// When we allow jerk
 	unsigned int idleCount;								// The number of times Spin was called and had no new moves to process
+	uint32_t idleStartTime;								// the time when we started to idle
 	uint32_t longestGcodeWaitInterval;					// the longest we had to wait for a new GCode
 
 	float tangents[3]; 									// Axis compensation - 90 degrees + angle gives angle between axes


### PR DESCRIPTION
# Description

This adds the `M595 Rnn` word to set a grace period, that is waited out before starting into moves. The grace period will make sure fine-grained, high volume move sequences will be received in full and can be look-ahead-planned properly, without rushing into premature deceleration. 

The `R` word is given in milliseconds and controls the command reception idle time that tells the `Move::Spin()`, that no more move command are pending. Note that `M400` (and others) will release the motion sequence immediately. A motion sequence closed with `M400` will therefore incur no additional wait time. 

The default grace period is 0ms, leaving everything as it was. 

# Justification

This option has been introduced after it was demonstrated that Duet would rush into premature deceleration on fine-grained interpolation move sequences sent from [OpenPnP](https://openpnp.org/). Due to the nature of these sequences (acceleration shaping a.k.a. "Simulated Jerk Control"), these motion sequences typically need to be look-ahead-planned right to the end, otherwise they will be degraded. 

# Usage

Example:

```
> M595 R3
ok
```

Sets a 3 millisecond grace period. This is sufficient for USB sending in the OpenPnP use case. Other, slower lines or "stammering" command senders might require higher values. 

The `M595` command without words reports the current settings:

```
> M595
DDAs 120, DMs 125, GracePeriod 3
```

# Testing

The changes have been tested with various hand crafted move sequences. Very large grace periods were used to confirm the proper waiting, move sequence recording, timed out execution and immediate execution with `M400`. 

OpenPnP was then used to test high resolution interpolation moves. Timing was confirmed to be in perfect agreement with the predicted motion: 

![OpenPnP Motion Diagnostics](https://user-images.githubusercontent.com/9963310/106511736-eac9c900-64d0-11eb-981f-03b2f68a5774.png)


USB communication is now the clear bottle-neck. 

# See also

- [OpenPnP Motion Interpolation](https://github.com/openpnp/openpnp/wiki/GcodeAsyncDriver#interpolation)
- [Current M595 command](https://duet3d.dozuki.com/Wiki/Gcode#Section_M595_Set_movement_queue_length)
- [Gif showing vibration problem on fast-driven cheap DIY Pick & Place machines, reason to control jerk.
   ![gif](https://user-images.githubusercontent.com/9963310/106511991-4bf19c80-64d1-11eb-8d83-4ec32cc25ea6.png)](https://makr.zone/wp-content/uploads/2020/04/Vibrations.gif)

- [Gif showing slip problem, another reason to control jerk.
   ![gif](https://user-images.githubusercontent.com/9963310/106512008-54e26e00-64d1-11eb-9240-3bd19e275fbf.png)](https://makr.zone/wp-content/uploads/2020/04/PartSlipping.gif)

- [Demo of "Simulated Jerk Control".
   ![png](https://user-images.githubusercontent.com/9963310/106512707-4052a580-64d2-11eb-9765-171e3e1af389.png)](https://makr.zone/wp-content/uploads/2020/04/SimulatedJerkControl.mp4)


  
   





