### PR TITLE
Pull Request: Filaments for all tools

### DIFF
--- a/src/GCodes/GCodes.cpp
+++ b/src/GCodes/GCodes.cpp
@@ -3857,12 +3857,6 @@ GCodeResult GCodes::LoadFilament(GCodeBuffer& gb, const StringRef& reply)
 			return GCodeResult::error;
 		}
 
-		if (Filament::IsInUse(filamentName.c_str()))
-		{
-			reply.copy("One filament type can be only assigned to a single tool");
-			return GCodeResult::error;
-		}
-
 		SafeStrncpy(filamentToLoad, filamentName.c_str(), ARRAY_SIZE(filamentToLoad));
 		gb.SetState(GCodeState::loadingFilament);
 


### PR DESCRIPTION
This allows a single Filament to be "loaded" into multiple tools. This allows a user to print "PETG" on multiple tools at the same time without having to create multiple copies of the "PETG" filament config to do so.

I left the actual `Filament::IsInUse` function intact. If you want it deleted for cleanup just let me know.

There is a corresponding change in DWC to allow this to work from the GUI: https://github.com/Duet3D/DuetWebControl/pull/330