### PR TITLE
Removes special handling of Hangprinter's D-anchor

### DIFF
--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -14,10 +14,10 @@
 
 // Default anchor coordinates
 // These are only placeholders. Each machine must have these values calibrated in order to work correctly.
-constexpr float DefaultAnchorA[3] = {    0.0, -2000.0, -100.0};
-constexpr float DefaultAnchorB[3] = { 2000.0,  1000.0, -100.0};
-constexpr float DefaultAnchorC[3] = {-2000.0,  1000.0, -100.0};
-constexpr float DefaultAnchorDz = 3000.0;
+constexpr float DefaultAnchors[4][3] = {{    0.0, -2000.0, -100.0},
+                                        { 2000.0,  1000.0, -100.0},
+                                        {-2000.0,  1000.0, -100.0},
+                                        {    0.0,     0.0, 3000.0}};
 constexpr float DefaultPrintRadius = 1500.0;
 
 #if SUPPORT_OBJECT_MODEL
@@ -29,40 +29,23 @@ constexpr float DefaultPrintRadius = 1500.0;
 // Macro to build a standard lambda function that includes the necessary type conversions
 #define OBJECT_MODEL_FUNC(...) OBJECT_MODEL_FUNC_BODY(HangprinterKinematics, __VA_ARGS__)
 
-constexpr ObjectModelArrayDescriptor HangprinterKinematics::anchorAArrayDescriptor =
+constexpr ObjectModelArrayDescriptor HangprinterKinematics::anchorsArrayDescriptor =
 {
 	nullptr,					// no lock needed
-	[] (const ObjectModel *self, const ObjectExplorationContext&) noexcept -> size_t { return 3; },
-	[] (const ObjectModel *self, ObjectExplorationContext& context) noexcept -> ExpressionValue { return ExpressionValue(((const HangprinterKinematics *)self)->anchorA[context.GetLastIndex()], 3); }
-};
-
-constexpr ObjectModelArrayDescriptor HangprinterKinematics::anchorBArrayDescriptor =
-{
-	nullptr,					// no lock needed
-	[] (const ObjectModel *self, const ObjectExplorationContext&) noexcept -> size_t { return 3; },
-	[] (const ObjectModel *self, ObjectExplorationContext& context) noexcept -> ExpressionValue { return ExpressionValue(((const HangprinterKinematics *)self)->anchorB[context.GetLastIndex()], 3); }
-};
-
-constexpr ObjectModelArrayDescriptor HangprinterKinematics::anchorCArrayDescriptor =
-{
-	nullptr,					// no lock needed
-	[] (const ObjectModel *self, const ObjectExplorationContext&) noexcept -> size_t { return 3; },
-	[] (const ObjectModel *self, ObjectExplorationContext& context) noexcept -> ExpressionValue { return ExpressionValue(((const HangprinterKinematics *)self)->anchorC[context.GetLastIndex()], 3); }
+	[] (const ObjectModel *self, const ObjectExplorationContext&) noexcept -> size_t { return HANGPRINTER_AXES*3; },
+	[] (const ObjectModel *self, ObjectExplorationContext& context) noexcept -> ExpressionValue { return ExpressionValue(((const HangprinterKinematics *)self)->anchors[context.GetIndex(1)][context.GetLastIndex()], 3); }
 };
 
 constexpr ObjectModelTableEntry HangprinterKinematics::objectModelTable[] =
 {
 	// Within each group, these entries must be in alphabetical order
 	// 0. kinematics members
-	{ "anchorA",	OBJECT_MODEL_FUNC_NOSELF(&anchorAArrayDescriptor), 	ObjectModelEntryFlags::none },
-	{ "anchorB",	OBJECT_MODEL_FUNC_NOSELF(&anchorBArrayDescriptor), 	ObjectModelEntryFlags::none },
-	{ "anchorC",	OBJECT_MODEL_FUNC_NOSELF(&anchorCArrayDescriptor), 	ObjectModelEntryFlags::none },
-	{ "anchorDz",	OBJECT_MODEL_FUNC(self->anchorDz, 3), 				ObjectModelEntryFlags::none },
+	{ "anchors",	OBJECT_MODEL_FUNC_NOSELF(&anchorsArrayDescriptor), 	ObjectModelEntryFlags::none },
 	{ "name",		OBJECT_MODEL_FUNC(self->GetName(true)), 			ObjectModelEntryFlags::none },
 	{ "printRadius",	OBJECT_MODEL_FUNC(self->printRadius, 1), 		ObjectModelEntryFlags::none },
 };
 
-constexpr uint8_t HangprinterKinematics::objectModelTableDescriptor[] = { 1, 6 };
+constexpr uint8_t HangprinterKinematics::objectModelTableDescriptor[] = { 1, 3 };
 
 DEFINE_GET_OBJECT_MODEL_TABLE(HangprinterKinematics)
 
@@ -77,11 +60,8 @@ HangprinterKinematics::HangprinterKinematics() noexcept
 
 void HangprinterKinematics::Init() noexcept
 {
-	anchorDz = DefaultAnchorDz;
 	printRadius = DefaultPrintRadius;
-	ARRAY_INIT(anchorA, DefaultAnchorA);
-	ARRAY_INIT(anchorB, DefaultAnchorB);
-	ARRAY_INIT(anchorC, DefaultAnchorC);
+	ARRAY_INIT(anchors, DefaultAnchors);
 	doneAutoCalibration = false;
 	Recalc();
 }
@@ -90,35 +70,35 @@ void HangprinterKinematics::Init() noexcept
 void HangprinterKinematics::Recalc() noexcept
 {
 	printRadiusSquared = fsquare(printRadius);
-	Da2 = fsquare(anchorA[0]) + fsquare(anchorA[1]) + fsquare(anchorA[2]);
-	Db2 = fsquare(anchorB[0]) + fsquare(anchorB[1]) + fsquare(anchorB[2]);
-	Dc2 = fsquare(anchorC[0]) + fsquare(anchorC[1]) + fsquare(anchorC[2]);
-	Xab = anchorA[0] - anchorB[0];
-	Xbc = anchorB[0] - anchorC[0];
-	Xca = anchorC[0] - anchorA[0];
-	Yab = anchorA[1] - anchorB[1];
-	Ybc = anchorB[1] - anchorC[1];
-	Yca = anchorC[1] - anchorA[1];
-	Zab = anchorA[2] - anchorB[2];
-	Zbc = anchorB[2] - anchorC[2];
-	Zca = anchorC[2] - anchorA[2];
-	P = (  anchorB[0] * Yca
-		 - anchorA[0] * anchorC[1]
-		 + anchorA[1] * anchorC[0]
-		 - anchorB[1] * Xca
+	Da2 = fsquare(anchors[A_AXIS][X_AXIS]) + fsquare(anchors[A_AXIS][Y_AXIS]) + fsquare(anchors[A_AXIS][Z_AXIS]);
+	Db2 = fsquare(anchors[B_AXIS][X_AXIS]) + fsquare(anchors[B_AXIS][Y_AXIS]) + fsquare(anchors[B_AXIS][Z_AXIS]);
+	Dc2 = fsquare(anchors[C_AXIS][X_AXIS]) + fsquare(anchors[C_AXIS][Y_AXIS]) + fsquare(anchors[C_AXIS][Z_AXIS]);
+	Xab = anchors[A_AXIS][X_AXIS] - anchors[B_AXIS][X_AXIS];
+	Xbc = anchors[B_AXIS][X_AXIS] - anchors[C_AXIS][X_AXIS];
+	Xca = anchors[C_AXIS][X_AXIS] - anchors[A_AXIS][X_AXIS];
+	Yab = anchors[A_AXIS][Y_AXIS] - anchors[B_AXIS][Y_AXIS];
+	Ybc = anchors[B_AXIS][Y_AXIS] - anchors[C_AXIS][Y_AXIS];
+	Yca = anchors[C_AXIS][Y_AXIS] - anchors[A_AXIS][Y_AXIS];
+	Zab = anchors[A_AXIS][Z_AXIS] - anchors[B_AXIS][Z_AXIS];
+	Zbc = anchors[B_AXIS][Z_AXIS] - anchors[C_AXIS][Z_AXIS];
+	Zca = anchors[C_AXIS][Z_AXIS] - anchors[A_AXIS][Z_AXIS];
+	P = (  anchors[B_AXIS][X_AXIS] * Yca
+		 - anchors[A_AXIS][X_AXIS] * anchors[C_AXIS][Y_AXIS]
+		 + anchors[A_AXIS][Y_AXIS] * anchors[C_AXIS][X_AXIS]
+		 - anchors[B_AXIS][Y_AXIS] * Xca
 		) * 2;
 	P2 = fsquare(P);
-	Q = (  anchorB[1] * Zca
-		 - anchorA[1] * anchorC[2]
-		 + anchorA[2] * anchorC[1]
-		 - anchorB[2] * Yca
+	Q = (  anchors[B_AXIS][Y_AXIS] * Zca
+		 - anchors[A_AXIS][Y_AXIS] * anchors[C_AXIS][Z_AXIS]
+		 + anchors[A_AXIS][Z_AXIS] * anchors[C_AXIS][Y_AXIS]
+		 - anchors[B_AXIS][Z_AXIS] * Yca
 		) * 2;
-	R = - (  anchorB[0] * Zca
-		   + anchorA[0] * anchorC[2]
-		   + anchorA[2] * anchorC[0]
-		   - anchorB[2] * Xca
+	R = - (  anchors[B_AXIS][X_AXIS] * Zca
+		   + anchors[A_AXIS][X_AXIS] * anchors[C_AXIS][Z_AXIS]
+		   + anchors[A_AXIS][Z_AXIS] * anchors[C_AXIS][X_AXIS]
+		   - anchors[B_AXIS][Z_AXIS] * Xca
 		  ) * 2;
-	U = (anchorA[2] * P2) + (anchorA[0] * Q * P) + (anchorA[1] * R * P);
+	U = (anchors[A_AXIS][Z_AXIS] * P2) + (anchors[A_AXIS][X_AXIS] * Q * P) + (anchors[A_AXIS][Y_AXIS] * R * P);
 	A = (P2 + fsquare(Q) + fsquare(R)) * 2;
 }
 
@@ -136,22 +116,26 @@ bool HangprinterKinematics::Configure(unsigned int mCode, GCodeBuffer& gb, const
 	{
 		const bool seenNonGeometry = TryConfigureSegmentation(gb);
 		bool seen = false;
-		if (gb.TryGetFloatArray('A', 3, anchorA, reply, seen))
+		if (gb.TryGetFloatArray('A', 3, anchors[A_AXIS], reply, seen))
 		{
 			error = true;
 			return true;
 		}
-		if (gb.TryGetFloatArray('B', 3, anchorB, reply, seen))
+		if (gb.TryGetFloatArray('B', 3, anchors[B_AXIS], reply, seen))
 		{
 			error = true;
 			return true;
 		}
-		if (gb.TryGetFloatArray('C', 3, anchorC, reply, seen))
+		if (gb.TryGetFloatArray('C', 3, anchors[C_AXIS], reply, seen))
 		{
 			error = true;
 			return true;
 		}
-		gb.TryGetFValue('D', anchorDz, seen);
+		if (gb.TryGetFloatArray('D', 3, anchors[D_AXIS], reply, seen))
+		{
+			error = true;
+			return true;
+		}
 
 		if (gb.Seen('P'))
 		{
@@ -165,12 +149,13 @@ bool HangprinterKinematics::Configure(unsigned int mCode, GCodeBuffer& gb, const
 		}
 		else if (!seenNonGeometry && !gb.Seen('K'))
 		{
-			reply.printf("Kinematics is Hangprinter with ABC anchor coordinates (%.2f,%.2f,%.2f) (%.2f,%.2f,%.2f) (%.2f,%.2f,%.2f),"
-							"D anchor Z coordinate %.2f, print radius %.1f, segments/sec %d, min. segment length %.2f",
-							(double)anchorA[X_AXIS], (double)anchorA[Y_AXIS], (double)anchorA[Z_AXIS],
-							(double)anchorB[X_AXIS], (double)anchorB[Y_AXIS], (double)anchorB[Z_AXIS],
-							(double)anchorC[X_AXIS], (double)anchorC[Y_AXIS], (double)anchorC[Z_AXIS],
-							(double)anchorDz, (double)printRadius,
+			reply.printf("Kinematics is Hangprinter with ABCD anchor coordinates (%.2f,%.2f,%.2f) (%.2f,%.2f,%.2f) (%.2f,%.2f,%.2f) (%.2f,%.2f,%.2f),"
+							"print radius %.1f, segments/sec %d, min. segment length %.2f",
+							(double)anchors[A_AXIS][X_AXIS], (double)anchors[A_AXIS][Y_AXIS], (double)anchors[A_AXIS][Z_AXIS],
+							(double)anchors[B_AXIS][X_AXIS], (double)anchors[B_AXIS][Y_AXIS], (double)anchors[B_AXIS][Z_AXIS],
+							(double)anchors[C_AXIS][X_AXIS], (double)anchors[C_AXIS][Y_AXIS], (double)anchors[C_AXIS][Z_AXIS],
+							(double)anchors[D_AXIS][X_AXIS], (double)anchors[D_AXIS][Y_AXIS], (double)anchors[D_AXIS][Z_AXIS],
+							(double)printRadius,
 							(int)segmentsPerSecond, (double)minSegmentLength);
 		}
 		return seen;
@@ -182,21 +167,19 @@ bool HangprinterKinematics::Configure(unsigned int mCode, GCodeBuffer& gb, const
 }
 
 // Calculate the square of the line length from a spool from a Cartesian coordinate
-inline float HangprinterKinematics::LineLengthSquared(const float machinePos[3], const float anchor[3]) const noexcept
+inline float HangprinterKinematics::LineLengthSquared(const float machinePos[3], const float anchors[3]) const noexcept
 {
-	return fsquare(anchor[Z_AXIS] - machinePos[Z_AXIS]) + fsquare(anchor[Y_AXIS] - machinePos[Y_AXIS]) + fsquare(anchor[X_AXIS] - machinePos[X_AXIS]);
+	return fsquare(anchors[Z_AXIS] - machinePos[Z_AXIS]) + fsquare(anchors[Y_AXIS] - machinePos[Y_AXIS]) + fsquare(anchors[X_AXIS] - machinePos[X_AXIS]);
 }
 
 // Convert Cartesian coordinates to motor coordinates, returning true if successful
 bool HangprinterKinematics::CartesianToMotorSteps(const float machinePos[], const float stepsPerMm[],
 													size_t numVisibleAxes, size_t numTotalAxes, int32_t motorPos[], bool isCoordinated) const noexcept
 {
-	const float aSquared = LineLengthSquared(machinePos, anchorA);
-	const float bSquared = LineLengthSquared(machinePos, anchorB);
-	const float cSquared = LineLengthSquared(machinePos, anchorC);
-	const float dSquared =    fsquare(machinePos[X_AXIS])
-							+ fsquare(machinePos[Y_AXIS])
-							+ fsquare(anchorDz - machinePos[Z_AXIS]);
+	const float aSquared = LineLengthSquared(machinePos, anchors[A_AXIS]);
+	const float bSquared = LineLengthSquared(machinePos, anchors[B_AXIS]);
+	const float cSquared = LineLengthSquared(machinePos, anchors[C_AXIS]);
+	const float dSquared = LineLengthSquared(machinePos, anchors[D_AXIS]);
 	if (aSquared > 0.0 && bSquared > 0.0 && cSquared > 0.0 && dSquared > 0.0)
 	{
 		motorPos[A_AXIS] = lrintf(fastSqrtf(aSquared) * stepsPerMm[A_AXIS]);
@@ -318,11 +301,12 @@ bool HangprinterKinematics::WriteCalibrationParameters(FileStore *f) const noexc
 	if (ok)
 	{
 		String<100> scratchString;
-		scratchString.printf("M669 K6 A%.3f:%.3f:%.3f B%.3f:%.3f:%.3f C%.3f:%.3f:%.3f D%.3f P%.1f\n",
-							(double)anchorA[X_AXIS], (double)anchorA[Y_AXIS], (double)anchorA[Z_AXIS],
-							(double)anchorB[X_AXIS], (double)anchorB[Y_AXIS], (double)anchorB[Z_AXIS],
-							(double)anchorC[X_AXIS], (double)anchorC[Y_AXIS], (double)anchorC[Z_AXIS],
-							(double)anchorDz, (double)printRadius);
+		scratchString.printf("M669 K6 A%.3f:%.3f:%.3f B%.3f:%.3f:%.3f C%.3f:%.3f:%.3f D%.3f:%.3f:%.3f P%.1f\n",
+							(double)anchors[A_AXIS][X_AXIS], (double)anchors[A_AXIS][Y_AXIS], (double)anchors[A_AXIS][Z_AXIS],
+							(double)anchors[B_AXIS][X_AXIS], (double)anchors[B_AXIS][Y_AXIS], (double)anchors[B_AXIS][Z_AXIS],
+							(double)anchors[C_AXIS][X_AXIS], (double)anchors[C_AXIS][Y_AXIS], (double)anchors[C_AXIS][Z_AXIS],
+							(double)anchors[D_AXIS][X_AXIS], (double)anchors[D_AXIS][Y_AXIS], (double)anchors[D_AXIS][Z_AXIS],
+							(double)printRadius);
 		ok = f->Write(scratchString.c_str());
 	}
 	return ok;
@@ -349,7 +333,7 @@ void HangprinterKinematics::InverseTransform(float La, float Lb, float Lc, float
 
 	// Calculate quadratic equation coefficients
 	const float halfB = (S * Q) - (R * T) - U;
-	const float C = fsquare(S) + fsquare(T) + (anchorA[1] * T - anchorA[0] * S) * P * 2 + (Da2 - fsquare(La)) * P2;
+	const float C = fsquare(S) + fsquare(T) + (anchors[A_AXIS][Y_AXIS] * T - anchors[A_AXIS][X_AXIS] * S) * P * 2 + (Da2 - fsquare(La)) * P2;
 
 	// Solve the quadratic equation for z
 	machinePos[2] = (- halfB - fastSqrtf(fsquare(halfB) - A * C))/A;
@@ -403,9 +387,9 @@ bool HangprinterKinematics::DoAutoCalibration(size_t numFactors, const RandomPro
 			const floatc_t zp = reprap.GetMove().GetProbeCoordinates(i, machinePos[X_AXIS], machinePos[Y_AXIS], probePoints.PointWasCorrected(i));
 			machinePos[Z_AXIS] = 0.0;
 
-			probeMotorPositions(i, A_AXIS) = fastSqrtf(LineLengthSquared(machinePos, anchorA));
-			probeMotorPositions(i, B_AXIS) = fastSqrtf(LineLengthSquared(machinePos, anchorB));
-			probeMotorPositions(i, C_AXIS) = fastSqrtf(LineLengthSquared(machinePos, anchorC));
+			probeMotorPositions(i, A_AXIS) = fastSqrtf(LineLengthSquared(machinePos, anchors[A_AXIS]));
+			probeMotorPositions(i, B_AXIS) = fastSqrtf(LineLengthSquared(machinePos, anchors[B_AXIS]));
+			probeMotorPositions(i, C_AXIS) = fastSqrtf(LineLengthSquared(machinePos, anchors[C_AXIS]));
 			initialSumOfSquares += fcsquare(zp);
 		}
 		initialDeviation.Set(initialSumOfSquares, initialSum, numPoints);
@@ -582,43 +566,43 @@ floatc_t HangprinterKinematics::ComputeDerivative(unsigned int deriv, float La, 
 		break;
 
 	case 3:
-		hiParams.anchorB[1] += perturb;
-		loParams.anchorB[1] -= perturb;
+		hiParams.anchors[B_AXIS][Y_AXIS] += perturb;
+		loParams.anchors[B_AXIS][Y_AXIS] -= perturb;
 		hiParams.Recalc();
 		loParams.Recalc();
 		break;
 
 	case 4:
-		hiParams.anchorC[0] += perturb;
-		loParams.anchorC[0] -= perturb;
+		hiParams.anchors[C_AXIS][X_AXIS] += perturb;
+		loParams.anchors[C_AXIS][X_AXIS] -= perturb;
 		hiParams.Recalc();
 		loParams.Recalc();
 		break;
 
 	case 5:
-		hiParams.anchorC[1] += perturb;
-		loParams.anchorC[1] -= perturb;
+		hiParams.anchors[C_AXIS][Y_AXIS] += perturb;
+		loParams.anchors[C_AXIS][Y_AXIS] -= perturb;
 		hiParams.Recalc();
 		loParams.Recalc();
 		break;
 
 	case 6:
-		hiParams.anchorA[2] += perturb;
-		loParams.anchorA[2] -= perturb;
+		hiParams.anchors[A_AXIS][Z_AXIS] += perturb;
+		loParams.anchors[A_AXIS][Z_AXIS] -= perturb;
 		hiParams.Recalc();
 		loParams.Recalc();
 		break;
 
 	case 7:
-		hiParams.anchorB[2] += perturb;
-		loParams.anchorB[2] -= perturb;
+		hiParams.anchors[B_AXIS][Z_AXIS] += perturb;
+		loParams.anchors[B_AXIS][Z_AXIS] -= perturb;
 		hiParams.Recalc();
 		loParams.Recalc();
 		break;
 
 	case 8:
-		hiParams.anchorB[2] += perturb;
-		loParams.anchorB[2] -= perturb;
+		hiParams.anchors[B_AXIS][Z_AXIS] += perturb;
+		loParams.anchors[B_AXIS][Z_AXIS] -= perturb;
 		hiParams.Recalc();
 		loParams.Recalc();
 		break;
@@ -643,27 +627,27 @@ void HangprinterKinematics::Adjust(size_t numFactors, const floatc_t v[]) noexce
 {
 	if (numFactors >= 4)
 	{
-		anchorB[1] += (float)v[3];
+		anchors[B_AXIS][Y_AXIS] += (float)v[3];
 	}
 	if (numFactors >= 5)
 	{
-		anchorC[0] += (float)v[4];
+		anchors[C_AXIS][X_AXIS] += (float)v[4];
 	}
 	if (numFactors >= 6)
 	{
-		anchorC[1] += (float)v[5];
+		anchors[C_AXIS][Y_AXIS] += (float)v[5];
 	}
 	if (numFactors >= 7)
 	{
-		anchorA[2] += (float)v[6];
+		anchors[A_AXIS][Z_AXIS] += (float)v[6];
 	}
 	if (numFactors >= 8)
 	{
-		anchorB[2] += (float)v[7];
+		anchors[B_AXIS][Z_AXIS] += (float)v[7];
 	}
 	if (numFactors >= 9)
 	{
-		anchorC[2] += (float)v[8];
+		anchors[C_AXIS][Z_AXIS] += (float)v[8];
 	}
 
 	Recalc();
@@ -673,9 +657,9 @@ void HangprinterKinematics::Adjust(size_t numFactors, const floatc_t v[]) noexce
 void HangprinterKinematics::PrintParameters(const StringRef& reply) const noexcept
 {
 	reply.printf("Anchor coordinates (%.2f,%.2f,%.2f) (%.2f,%.2f,%.2f) (%.2f,%.2f,%.2f)\n",
-					(double)anchorA[X_AXIS], (double)anchorA[Y_AXIS], (double)anchorA[Z_AXIS],
-					(double)anchorB[X_AXIS], (double)anchorB[Y_AXIS], (double)anchorB[Z_AXIS],
-					(double)anchorC[X_AXIS], (double)anchorC[Y_AXIS], (double)anchorC[Z_AXIS]);
+					(double)anchors[A_AXIS][X_AXIS], (double)anchors[A_AXIS][Y_AXIS], (double)anchors[A_AXIS][Z_AXIS],
+					(double)anchors[B_AXIS][X_AXIS], (double)anchors[B_AXIS][Y_AXIS], (double)anchors[B_AXIS][Z_AXIS],
+					(double)anchors[C_AXIS][X_AXIS], (double)anchors[C_AXIS][Y_AXIS], (double)anchors[C_AXIS][Z_AXIS]);
 }
 
 // End

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -43,9 +43,7 @@ public:
 
 protected:
 	DECLARE_OBJECT_MODEL
-	OBJECT_MODEL_ARRAY(anchorA)
-	OBJECT_MODEL_ARRAY(anchorB)
-	OBJECT_MODEL_ARRAY(anchorC)
+	OBJECT_MODEL_ARRAY(anchors)
 
 private:
 	// Basic facts about movement system
@@ -64,8 +62,7 @@ private:
 	void Adjust(size_t numFactors, const floatc_t v[]) noexcept;									// Perform 3-, 6- or 9-factor adjustment
 	void PrintParameters(const StringRef& reply) const noexcept;									// Print all the parameters for debugging
 
-	float anchorA[3], anchorB[3], anchorC[3];				// XYZ coordinates of the anchors
-	float anchorDz;
+	float anchors[HANGPRINTER_AXES][3];				// XYZ coordinates of the anchors
 	float printRadius;
 
 	// Derived parameters

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -57,6 +57,7 @@ private:
 	void Recalc() noexcept;
 	float LineLengthSquared(const float machinePos[3], const float anchor[3]) const noexcept;		// Calculate the square of the line length from a spool from a Cartesian coordinate
 	void InverseTransform(float La, float Lb, float Lc, float machinePos[3]) const noexcept;
+	float MotorPosToLinePos(const int32_t motorPos, size_t axis) const noexcept;
 
 	floatc_t ComputeDerivative(unsigned int deriv, float La, float Lb, float Lc) const noexcept;	// Compute the derivative of height with respect to a parameter at a set of motor endpoints
 	void Adjust(size_t numFactors, const floatc_t v[]) noexcept;									// Perform 3-, 6- or 9-factor adjustment
@@ -64,8 +65,15 @@ private:
 
 	float anchors[HANGPRINTER_AXES][3];				// XYZ coordinates of the anchors
 	float printRadius;
+	// Line buildup compensation
+	float spoolBuildupFactor;
+	float spoolRadii[HANGPRINTER_AXES];
+	uint32_t mechanicalAdvantage[HANGPRINTER_AXES], linesPerSpool[HANGPRINTER_AXES];
+	uint32_t motorGearTeeth[HANGPRINTER_AXES], spoolGearTeeth[HANGPRINTER_AXES], fullStepsPerMotorRev[HANGPRINTER_AXES];
 
 	// Derived parameters
+	float k0[HANGPRINTER_AXES], spoolRadiiSq[HANGPRINTER_AXES], k2[HANGPRINTER_AXES], lineLengthsOrigin[HANGPRINTER_AXES];
+	float printRadiusSquared;
 	float Da2, Db2, Dc2;
 	float Xab, Xbc, Xca;
 	float Yab, Ybc, Yca;


### PR DESCRIPTION
There's nothing special about the D-anchor.

Allowing it to have non-zero xy-locations is very useful,
especially when auto-calibrating the anchor locations with help
of computer vision.

Code also gets easier to maintain, with less implicit knowledge
about Hangprinters needed.

The cost of this niceness is that the binary gets 164 bytes bigger.

I will place the line buildup compensation commit on top of this one, in the hope that 164 bytes is a manageable cost.