### PR TITLE
3.4 WIP: Allow up to 9 anchors/motors to be configured in hangprinter kinematics.

### DIFF
--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -96,6 +96,7 @@ void HangprinterKinematics::Init() noexcept
 	constexpr uint32_t DefaultFullStepsPerMotorRev[HANGPRINTER_MAX_AXES] = { 25, 25, 25, 25, 25, 25, 25, 25, 25};
 	ARRAY_INIT(anchors, DefaultAnchors);
 	numAnchors = DefaultNumAnchors;
+	anchorsSetup = LastTopRestDown;
 	printRadius = DefaultPrintRadius;
 	spoolBuildupFactor = DefaultSpoolBuildupFactor;
 	ARRAY_INIT(spoolRadii, DefaultSpoolRadii);
@@ -359,7 +360,9 @@ static bool isSameSide(float const v0[3], float const v1[3], float const v2[3], 
 	return dot0*dot1 > 0.0F;
 }
 
-bool HangprinterKinematics::IsReachable(float axesCoords[MaxAxes], AxesBitmap axes) const noexcept /*override*/
+// The last axe must be the one on the top
+// TODO Validate this in HangprinterKinematics::Configure
+bool HangprinterKinematics::IsReachablePyramid(float axesCoords[MaxAxes], AxesBitmap axes) const noexcept /*override*/
 {
 	float const coords[3] = {axesCoords[X_AXIS], axesCoords[Y_AXIS], axesCoords[Z_AXIS]};
 
@@ -379,6 +382,23 @@ bool HangprinterKinematics::IsReachable(float axesCoords[MaxAxes], AxesBitmap ax
 	}
 
 	return reachable;
+}
+
+bool HangprinterKinematics::IsReachablePrism(float axesCoords[MaxAxes], AxesBitmap axes) const noexcept
+{
+	// TODO Implement. We will need some sort of max height parameter since it's not implicit here.
+	return true;
+}
+
+bool HangprinterKinematics::IsReachable(float axesCoords[MaxAxes], AxesBitmap axes) const noexcept
+{
+	switch (anchorsSetup) {
+		case LastTopRestDown:
+		default:
+			return IsReachablePyramid(axesCoords, axes);
+		case AllTop:
+			return IsReachablePrism(axesCoords, axes);
+	}
 }
 
 // Limit the Cartesian position that the user wants to move to returning true if we adjusted the position

--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -20,10 +20,11 @@
 constexpr size_t DefaultNumAnchors = 4;
 // Default anchor coordinates
 // These are only placeholders. Each machine must have these values calibrated in order to work correctly.
-constexpr float DefaultAnchors[7][3] = {{    0.0, -2000.0, -100.0},
+constexpr float DefaultAnchors[8][3] = {{    0.0, -2000.0, -100.0},
                                         { 2000.0,  1000.0, -100.0},
                                         {-2000.0,  1000.0, -100.0},
                                         {    0.0,     0.0, 3000.0},
+                                        {    0.0,     0.0,    0.0},
                                         {    0.0,     0.0,    0.0},
                                         {    0.0,     0.0,    0.0},
                                         {    0.0,     0.0,    0.0}};
@@ -85,13 +86,13 @@ void HangprinterKinematics::Init() noexcept
 	 * In practice you might want to compensate a bit more or a bit less */
 	constexpr float DefaultSpoolBuildupFactor = 0.007;
 	/* Measure and set spool radii with M669 to achieve better accuracy */
-	constexpr float DefaultSpoolRadii[HANGPRINTER_MAX_AXES] = { 75.0, 75.0, 75.0, 75.0, 75.0, 75.0, 75.0}; // HP4 default
+	constexpr float DefaultSpoolRadii[HANGPRINTER_MAX_AXES] = { 75.0, 75.0, 75.0, 75.0, 75.0, 75.0, 75.0, 75.0}; // HP4 default
 	/* If axis runs lines back through pulley system, set mechanical advantage accordingly with M669 */
-	constexpr uint32_t DefaultMechanicalAdvantage[HANGPRINTER_MAX_AXES] = { 2, 2, 2, 2, 2, 2, 4}; // HP4 default
-	constexpr uint32_t DefaultLinesPerSpool[HANGPRINTER_MAX_AXES] = { 1, 1, 1, 1, 1, 1, 1}; // HP4 default
-	constexpr uint32_t DefaultMotorGearTeeth[HANGPRINTER_MAX_AXES] = {  20,  20,  20,  20,  20,  20,  20}; // HP4 default
-	constexpr uint32_t DefaultSpoolGearTeeth[HANGPRINTER_MAX_AXES] = { 255, 255, 255, 255, 255, 255, 255}; // HP4 default
-	constexpr uint32_t DefaultFullStepsPerMotorRev[HANGPRINTER_MAX_AXES] = { 25, 25, 25, 25, 25, 25, 25};
+	constexpr uint32_t DefaultMechanicalAdvantage[HANGPRINTER_MAX_AXES] = { 2, 2, 2, 2, 2, 2, 2, 4}; // HP4 default
+	constexpr uint32_t DefaultLinesPerSpool[HANGPRINTER_MAX_AXES] = { 1, 1, 1, 1, 1, 1, 1, 1}; // HP4 default
+	constexpr uint32_t DefaultMotorGearTeeth[HANGPRINTER_MAX_AXES] = {  20,  20,  20,  20,  20,  20,  20,  20}; // HP4 default
+	constexpr uint32_t DefaultSpoolGearTeeth[HANGPRINTER_MAX_AXES] = { 255, 255, 255, 255, 255, 255, 255, 255}; // HP4 default
+	constexpr uint32_t DefaultFullStepsPerMotorRev[HANGPRINTER_MAX_AXES] = { 25, 25, 25, 25, 25, 25, 25, 25};
 	ARRAY_INIT(anchors, DefaultAnchors);
 	numAnchors = DefaultNumAnchors;
 	printRadius = DefaultPrintRadius;
@@ -676,8 +677,8 @@ void HangprinterKinematics::PrintParameters(const StringRef& reply) const noexce
 HangprinterKinematics::ODriveAnswer HangprinterKinematics::GetODrive3EncoderEstimate(DriverId const driver, bool const makeReference, const StringRef& reply, bool const subtractReference) THROWS(GCodeException)
 {
 	const uint8_t cmd = CANSimple::MSG_GET_ENCODER_ESTIMATES;
-	static CanAddress seenDrives[HANGPRINTER_MAX_AXES] = { 0, 0, 0, 0, 0, 0, 0 };
-	static float referencePositions[HANGPRINTER_MAX_AXES] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+	static CanAddress seenDrives[HANGPRINTER_MAX_AXES] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+	static float referencePositions[HANGPRINTER_MAX_AXES] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 	static size_t numSeenDrives = 0;
 	size_t thisDriveIdx = 0;
 

--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -153,7 +153,7 @@ const char *HangprinterKinematics::GetName(bool forStatusReport) const noexcept
 
 // Set the parameters from a M665, M666 or M669 command
 // Return true if we changed any parameters that affect the geometry. Set 'error' true if there was an error, otherwise leave it alone.
-bool HangprinterKinematics::Configure(unsigned int mCode, GCodeBuffer& gb, const StringRef& reply, bool& error) THROWS(GCodeException) /*override*/
+bool HangprinterKinematics::Configure(unsigned int mCode, GCodeBuffer& gb, const StringRef& reply, OutputBuffer *& buf, bool& error) THROWS(GCodeException) /*override*/
 {
 	bool seen = false;
 	if (mCode == 669)

--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -353,30 +353,26 @@ static bool isSameSide(float const v0[3], float const v1[3], float const v2[3], 
 	return dot0*dot1 > 0.0F;
 }
 
-static bool isInsideTetrahedron(float const point[3], float const tetrahedron[4][3]){
-	return isSameSide(tetrahedron[0], tetrahedron[1], tetrahedron[2], tetrahedron[3], point) &&
-	       isSameSide(tetrahedron[2], tetrahedron[1], tetrahedron[3], tetrahedron[0], point) &&
-	       isSameSide(tetrahedron[2], tetrahedron[3], tetrahedron[0], tetrahedron[1], point) &&
-	       isSameSide(tetrahedron[0], tetrahedron[3], tetrahedron[1], tetrahedron[2], point);
-}
-
-static bool isInsideSquarePyramid(float const point[3], float const squarePyramid[5][3]){
-	return isSameSide(squarePyramid[0], squarePyramid[1], squarePyramid[2], squarePyramid[4], point) &&
-	       isSameSide(squarePyramid[2], squarePyramid[1], squarePyramid[4], squarePyramid[0], point) &&
-	       isSameSide(squarePyramid[2], squarePyramid[4], squarePyramid[3], squarePyramid[1], point) &&
-	       isSameSide(squarePyramid[0], squarePyramid[4], squarePyramid[3], squarePyramid[2], point) &&
-	       isSameSide(squarePyramid[0], squarePyramid[4], squarePyramid[1], squarePyramid[3], point);
-}
-
 bool HangprinterKinematics::IsReachable(float axesCoords[MaxAxes], AxesBitmap axes) const noexcept /*override*/
 {
 	float const coords[3] = {axesCoords[X_AXIS], axesCoords[Y_AXIS], axesCoords[Z_AXIS]};
-	switch(numAnchors)
+
+	bool reachable = isSameSide(anchors[0], anchors[1], anchors[2], anchors[numAnchors - 1], coords);
+
+	for (size_t i = 1; reachable && i < numAnchors - 3; ++i)
 	{
-	case 5:	return isInsideSquarePyramid(coords, anchors);
-	default:
-	case 4:	return isInsideTetrahedron(coords, anchors);
+		reachable = isSameSide(anchors[i], anchors[i + 1], anchors[numAnchors - 1], anchors[i + 2], coords);
 	}
+	if (reachable)
+	{
+		reachable = isSameSide(anchors[numAnchors - 3], anchors[numAnchors - 2], anchors[numAnchors - 1], anchors[0], coords);
+	}
+	if (reachable)
+	{
+		reachable = isSameSide(anchors[numAnchors - 2], anchors[0], anchors[numAnchors - 1], anchors[1], coords);
+	}
+
+	return reachable;
 }
 
 // Limit the Cartesian position that the user wants to move to returning true if we adjusted the position

--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -20,10 +20,11 @@
 constexpr size_t DefaultNumAnchors = 4;
 // Default anchor coordinates
 // These are only placeholders. Each machine must have these values calibrated in order to work correctly.
-constexpr float DefaultAnchors[5][3] = {{    0.0, -2000.0, -100.0},
+constexpr float DefaultAnchors[6][3] = {{    0.0, -2000.0, -100.0},
                                         { 2000.0,  1000.0, -100.0},
                                         {-2000.0,  1000.0, -100.0},
                                         {    0.0,     0.0, 3000.0},
+                                        {    0.0,     0.0,    0.0},
                                         {    0.0,     0.0,    0.0}};
 constexpr float DefaultPrintRadius = 1500.0;
 
@@ -83,13 +84,13 @@ void HangprinterKinematics::Init() noexcept
 	 * In practice you might want to compensate a bit more or a bit less */
 	constexpr float DefaultSpoolBuildupFactor = 0.007;
 	/* Measure and set spool radii with M669 to achieve better accuracy */
-	constexpr float DefaultSpoolRadii[HANGPRINTER_MAX_AXES] = { 75.0, 75.0, 75.0, 75.0, 75.0}; // HP4 default
+	constexpr float DefaultSpoolRadii[HANGPRINTER_MAX_AXES] = { 75.0, 75.0, 75.0, 75.0, 75.0, 75.0}; // HP4 default
 	/* If axis runs lines back through pulley system, set mechanical advantage accordingly with M669 */
-	constexpr uint32_t DefaultMechanicalAdvantage[HANGPRINTER_MAX_AXES] = { 2, 2, 2, 2, 4}; // HP4 default
-	constexpr uint32_t DefaultLinesPerSpool[HANGPRINTER_MAX_AXES] = { 1, 1, 1, 1, 1}; // HP4 default
-	constexpr uint32_t DefaultMotorGearTeeth[HANGPRINTER_MAX_AXES] = {  20,  20,  20,  20,  20}; // HP4 default
-	constexpr uint32_t DefaultSpoolGearTeeth[HANGPRINTER_MAX_AXES] = { 255, 255, 255, 255, 255}; // HP4 default
-	constexpr uint32_t DefaultFullStepsPerMotorRev[HANGPRINTER_MAX_AXES] = { 25, 25, 25, 25, 25};
+	constexpr uint32_t DefaultMechanicalAdvantage[HANGPRINTER_MAX_AXES] = { 2, 2, 2, 2, 2, 4}; // HP4 default
+	constexpr uint32_t DefaultLinesPerSpool[HANGPRINTER_MAX_AXES] = { 1, 1, 1, 1, 1, 1}; // HP4 default
+	constexpr uint32_t DefaultMotorGearTeeth[HANGPRINTER_MAX_AXES] = {  20,  20,  20,  20,  20,  20}; // HP4 default
+	constexpr uint32_t DefaultSpoolGearTeeth[HANGPRINTER_MAX_AXES] = { 255, 255, 255, 255, 255, 255}; // HP4 default
+	constexpr uint32_t DefaultFullStepsPerMotorRev[HANGPRINTER_MAX_AXES] = { 25, 25, 25, 25, 25, 25};
 	ARRAY_INIT(anchors, DefaultAnchors);
 	numAnchors = DefaultNumAnchors;
 	printRadius = DefaultPrintRadius;
@@ -167,6 +168,7 @@ bool HangprinterKinematics::Configure(unsigned int mCode, GCodeBuffer& gb, const
 				return true;
 			}
 		}
+
 		if (gb.Seen('P'))
 		{
 			printRadius = gb.GetFValue();
@@ -490,6 +492,7 @@ bool HangprinterKinematics::WriteCalibrationParameters(FileStore *f) const noexc
 	{
 		scratchString.catf("%c%.3f:%.3f:%.3f ", ANCHOR_CHARS[i], (double)anchors[i][X_AXIS], (double)anchors[i][Y_AXIS], (double)anchors[i][Z_AXIS]);
 	}
+
 	if (!f->Write(scratchString.c_str()))
 	{
 		return false;
@@ -671,8 +674,8 @@ void HangprinterKinematics::PrintParameters(const StringRef& reply) const noexce
 HangprinterKinematics::ODriveAnswer HangprinterKinematics::GetODrive3EncoderEstimate(DriverId const driver, bool const makeReference, const StringRef& reply, bool const subtractReference) THROWS(GCodeException)
 {
 	const uint8_t cmd = CANSimple::MSG_GET_ENCODER_ESTIMATES;
-	static CanAddress seenDrives[HANGPRINTER_MAX_AXES] = { 0, 0, 0, 0, 0 };
-	static float referencePositions[HANGPRINTER_MAX_AXES] = { 0.0, 0.0, 0.0, 0.0, 0.0 };
+	static CanAddress seenDrives[HANGPRINTER_MAX_AXES] = { 0, 0, 0, 0, 0, 0 };
+	static float referencePositions[HANGPRINTER_MAX_AXES] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 	static size_t numSeenDrives = 0;
 	size_t thisDriveIdx = 0;
 

--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -20,10 +20,11 @@
 constexpr size_t DefaultNumAnchors = 4;
 // Default anchor coordinates
 // These are only placeholders. Each machine must have these values calibrated in order to work correctly.
-constexpr float DefaultAnchors[6][3] = {{    0.0, -2000.0, -100.0},
+constexpr float DefaultAnchors[7][3] = {{    0.0, -2000.0, -100.0},
                                         { 2000.0,  1000.0, -100.0},
                                         {-2000.0,  1000.0, -100.0},
                                         {    0.0,     0.0, 3000.0},
+                                        {    0.0,     0.0,    0.0},
                                         {    0.0,     0.0,    0.0},
                                         {    0.0,     0.0,    0.0}};
 constexpr float DefaultPrintRadius = 1500.0;
@@ -84,13 +85,13 @@ void HangprinterKinematics::Init() noexcept
 	 * In practice you might want to compensate a bit more or a bit less */
 	constexpr float DefaultSpoolBuildupFactor = 0.007;
 	/* Measure and set spool radii with M669 to achieve better accuracy */
-	constexpr float DefaultSpoolRadii[HANGPRINTER_MAX_AXES] = { 75.0, 75.0, 75.0, 75.0, 75.0, 75.0}; // HP4 default
+	constexpr float DefaultSpoolRadii[HANGPRINTER_MAX_AXES] = { 75.0, 75.0, 75.0, 75.0, 75.0, 75.0, 75.0}; // HP4 default
 	/* If axis runs lines back through pulley system, set mechanical advantage accordingly with M669 */
-	constexpr uint32_t DefaultMechanicalAdvantage[HANGPRINTER_MAX_AXES] = { 2, 2, 2, 2, 2, 4}; // HP4 default
-	constexpr uint32_t DefaultLinesPerSpool[HANGPRINTER_MAX_AXES] = { 1, 1, 1, 1, 1, 1}; // HP4 default
-	constexpr uint32_t DefaultMotorGearTeeth[HANGPRINTER_MAX_AXES] = {  20,  20,  20,  20,  20,  20}; // HP4 default
-	constexpr uint32_t DefaultSpoolGearTeeth[HANGPRINTER_MAX_AXES] = { 255, 255, 255, 255, 255, 255}; // HP4 default
-	constexpr uint32_t DefaultFullStepsPerMotorRev[HANGPRINTER_MAX_AXES] = { 25, 25, 25, 25, 25, 25};
+	constexpr uint32_t DefaultMechanicalAdvantage[HANGPRINTER_MAX_AXES] = { 2, 2, 2, 2, 2, 2, 4}; // HP4 default
+	constexpr uint32_t DefaultLinesPerSpool[HANGPRINTER_MAX_AXES] = { 1, 1, 1, 1, 1, 1, 1}; // HP4 default
+	constexpr uint32_t DefaultMotorGearTeeth[HANGPRINTER_MAX_AXES] = {  20,  20,  20,  20,  20,  20,  20}; // HP4 default
+	constexpr uint32_t DefaultSpoolGearTeeth[HANGPRINTER_MAX_AXES] = { 255, 255, 255, 255, 255, 255, 255}; // HP4 default
+	constexpr uint32_t DefaultFullStepsPerMotorRev[HANGPRINTER_MAX_AXES] = { 25, 25, 25, 25, 25, 25, 25};
 	ARRAY_INIT(anchors, DefaultAnchors);
 	numAnchors = DefaultNumAnchors;
 	printRadius = DefaultPrintRadius;
@@ -183,6 +184,7 @@ bool HangprinterKinematics::Configure(unsigned int mCode, GCodeBuffer& gb, const
 		{
 			Kinematics::Configure(mCode, gb, reply, error);
 			reply.lcatf("P:Print radius: %.1f", (double)printRadius);
+			// TODO FIX messages are too long if there are 7 anchors or more
 			for (size_t i = 0; i < numAnchors; ++i)
 			{
 				reply.lcatf("%c:%.2f, %.2f, %.2f",
@@ -674,8 +676,8 @@ void HangprinterKinematics::PrintParameters(const StringRef& reply) const noexce
 HangprinterKinematics::ODriveAnswer HangprinterKinematics::GetODrive3EncoderEstimate(DriverId const driver, bool const makeReference, const StringRef& reply, bool const subtractReference) THROWS(GCodeException)
 {
 	const uint8_t cmd = CANSimple::MSG_GET_ENCODER_ESTIMATES;
-	static CanAddress seenDrives[HANGPRINTER_MAX_AXES] = { 0, 0, 0, 0, 0, 0 };
-	static float referencePositions[HANGPRINTER_MAX_AXES] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+	static CanAddress seenDrives[HANGPRINTER_MAX_AXES] = { 0, 0, 0, 0, 0, 0, 0 };
+	static float referencePositions[HANGPRINTER_MAX_AXES] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 	static size_t numSeenDrives = 0;
 	size_t thisDriveIdx = 0;
 

--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -20,10 +20,11 @@
 constexpr size_t DefaultNumAnchors = 4;
 // Default anchor coordinates
 // These are only placeholders. Each machine must have these values calibrated in order to work correctly.
-constexpr float DefaultAnchors[8][3] = {{    0.0, -2000.0, -100.0},
+constexpr float DefaultAnchors[9][3] = {{    0.0, -2000.0, -100.0},
                                         { 2000.0,  1000.0, -100.0},
                                         {-2000.0,  1000.0, -100.0},
                                         {    0.0,     0.0, 3000.0},
+                                        {    0.0,     0.0,    0.0},
                                         {    0.0,     0.0,    0.0},
                                         {    0.0,     0.0,    0.0},
                                         {    0.0,     0.0,    0.0},
@@ -86,13 +87,13 @@ void HangprinterKinematics::Init() noexcept
 	 * In practice you might want to compensate a bit more or a bit less */
 	constexpr float DefaultSpoolBuildupFactor = 0.007;
 	/* Measure and set spool radii with M669 to achieve better accuracy */
-	constexpr float DefaultSpoolRadii[HANGPRINTER_MAX_AXES] = { 75.0, 75.0, 75.0, 75.0, 75.0, 75.0, 75.0, 75.0}; // HP4 default
+	constexpr float DefaultSpoolRadii[HANGPRINTER_MAX_AXES] = { 75.0, 75.0, 75.0, 75.0, 75.0, 75.0, 75.0, 75.0, 75.0}; // HP4 default
 	/* If axis runs lines back through pulley system, set mechanical advantage accordingly with M669 */
-	constexpr uint32_t DefaultMechanicalAdvantage[HANGPRINTER_MAX_AXES] = { 2, 2, 2, 2, 2, 2, 2, 4}; // HP4 default
-	constexpr uint32_t DefaultLinesPerSpool[HANGPRINTER_MAX_AXES] = { 1, 1, 1, 1, 1, 1, 1, 1}; // HP4 default
-	constexpr uint32_t DefaultMotorGearTeeth[HANGPRINTER_MAX_AXES] = {  20,  20,  20,  20,  20,  20,  20,  20}; // HP4 default
-	constexpr uint32_t DefaultSpoolGearTeeth[HANGPRINTER_MAX_AXES] = { 255, 255, 255, 255, 255, 255, 255, 255}; // HP4 default
-	constexpr uint32_t DefaultFullStepsPerMotorRev[HANGPRINTER_MAX_AXES] = { 25, 25, 25, 25, 25, 25, 25, 25};
+	constexpr uint32_t DefaultMechanicalAdvantage[HANGPRINTER_MAX_AXES] = { 2, 2, 2, 2, 2, 2, 2, 2, 4}; // HP4 default
+	constexpr uint32_t DefaultLinesPerSpool[HANGPRINTER_MAX_AXES] = { 1, 1, 1, 1, 1, 1, 1, 1, 1}; // HP4 default
+	constexpr uint32_t DefaultMotorGearTeeth[HANGPRINTER_MAX_AXES] = {  20,  20,  20,  20,  20,  20,  20,  20,  20}; // HP4 default
+	constexpr uint32_t DefaultSpoolGearTeeth[HANGPRINTER_MAX_AXES] = { 255, 255, 255, 255, 255, 255, 255, 255, 255}; // HP4 default
+	constexpr uint32_t DefaultFullStepsPerMotorRev[HANGPRINTER_MAX_AXES] = { 25, 25, 25, 25, 25, 25, 25, 25, 25};
 	ARRAY_INIT(anchors, DefaultAnchors);
 	numAnchors = DefaultNumAnchors;
 	printRadius = DefaultPrintRadius;
@@ -677,8 +678,8 @@ void HangprinterKinematics::PrintParameters(const StringRef& reply) const noexce
 HangprinterKinematics::ODriveAnswer HangprinterKinematics::GetODrive3EncoderEstimate(DriverId const driver, bool const makeReference, const StringRef& reply, bool const subtractReference) THROWS(GCodeException)
 {
 	const uint8_t cmd = CANSimple::MSG_GET_ENCODER_ESTIMATES;
-	static CanAddress seenDrives[HANGPRINTER_MAX_AXES] = { 0, 0, 0, 0, 0, 0, 0, 0 };
-	static float referencePositions[HANGPRINTER_MAX_AXES] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+	static CanAddress seenDrives[HANGPRINTER_MAX_AXES] = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+	static float referencePositions[HANGPRINTER_MAX_AXES] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 	static size_t numSeenDrives = 0;
 	size_t thisDriveIdx = 0;
 

--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -443,48 +443,59 @@ AxesBitmap HangprinterKinematics::MustBeHomedAxes(AxesBitmap axesMoving, bool di
 // Write the parameters to a file, returning true if success
 bool HangprinterKinematics::WriteCalibrationParameters(FileStore *f) const noexcept
 {
-	bool ok = f->Write("; Hangprinter parameters\n");
-	if (ok)
+	if (!f->Write("; Hangprinter parameters\n"))
 	{
-		String<100> scratchString;
-		scratchString.printf("M669 K6 A%.3f:%.3f:%.3f B%.3f:%.3f:%.3f",
-							(double)anchors[A_AXIS][X_AXIS], (double)anchors[A_AXIS][Y_AXIS], (double)anchors[A_AXIS][Z_AXIS],
-							(double)anchors[B_AXIS][X_AXIS], (double)anchors[B_AXIS][Y_AXIS], (double)anchors[B_AXIS][Z_AXIS]);
-		ok = f->Write(scratchString.c_str());
-		if (ok)
-		{
-			scratchString.printf(" C%.3f:%.3f:%.3f D%.3f:%.3f:%.3f P%.1f\n",
-								(double)anchors[C_AXIS][X_AXIS], (double)anchors[C_AXIS][Y_AXIS], (double)anchors[C_AXIS][Z_AXIS],
-								(double)anchors[D_AXIS][X_AXIS], (double)anchors[D_AXIS][Y_AXIS], (double)anchors[D_AXIS][Z_AXIS],
-								(double)printRadius);
-			ok = f->Write(scratchString.c_str());
-			if (ok)
-			{
-				scratchString.printf("M666 Q%.6f R%.3f:%.3f:%.3f:%.3f U%d:%d:%d:%d",
-									(double)spoolBuildupFactor, (double)spoolRadii[A_AXIS],
-									(double)spoolRadii[B_AXIS], (double)spoolRadii[C_AXIS], (double)spoolRadii[D_AXIS],
-									(int)mechanicalAdvantage[A_AXIS], (int)mechanicalAdvantage[B_AXIS],
-									(int)mechanicalAdvantage[C_AXIS], (int)mechanicalAdvantage[D_AXIS]
-						);
-				ok = f->Write(scratchString.c_str());
-				if (ok)
-				{
-					scratchString.printf(" O%d:%d:%d:%d L%d:%d:%d:%d H%d:%d:%d:%d J%d:%d:%d:%d\n",
-										(int)linesPerSpool[A_AXIS], (int)linesPerSpool[B_AXIS],
-										(int)linesPerSpool[C_AXIS], (int)linesPerSpool[D_AXIS],
-										(int)motorGearTeeth[A_AXIS], (int)motorGearTeeth[B_AXIS],
-										(int)motorGearTeeth[C_AXIS], (int)motorGearTeeth[D_AXIS],
-										(int)spoolGearTeeth[A_AXIS], (int)spoolGearTeeth[B_AXIS],
-										(int)spoolGearTeeth[C_AXIS], (int)spoolGearTeeth[D_AXIS],
-										(int)fullStepsPerMotorRev[A_AXIS], (int)fullStepsPerMotorRev[B_AXIS],
-										(int)fullStepsPerMotorRev[C_AXIS], (int)fullStepsPerMotorRev[D_AXIS]
-							);
-					ok = f->Write(scratchString.c_str());
-				}
-			}
-		}
+		return false;
 	}
-	return ok;
+
+	String<255> scratchString;
+	scratchString.printf("M669 K6 P%.1f ", (double)printRadius);
+
+	for (size_t i = 0; i < HANGPRINTER_AXES; ++i)
+	{
+		scratchString.catf("%c%.3f:%.3f:%.3f ", ANCHOR_CHARS[i], (double)anchors[i][X_AXIS], (double)anchors[i][Y_AXIS], (double)anchors[i][Z_AXIS]);
+	}
+	if (!f->Write(scratchString.c_str()))
+	{
+		return false;
+	}
+
+	scratchString.printf("M666 Q%.6f ", (double)spoolBuildupFactor);
+	if (!f->Write(scratchString.c_str()))
+	{
+		return false;
+	}
+	scratchString.printf("R%.3f:%.3f:%.3f:%.3f", (double)spoolRadii[A_AXIS], (double)spoolRadii[B_AXIS], (double)spoolRadii[C_AXIS], (double)spoolRadii[D_AXIS]);
+	if (!f->Write(scratchString.c_str()))
+	{
+		return false;
+	}
+	scratchString.printf("U%d:%d:%d:%d", (int)mechanicalAdvantage[A_AXIS], (int)mechanicalAdvantage[B_AXIS], (int)mechanicalAdvantage[C_AXIS], (int)mechanicalAdvantage[D_AXIS]);
+	if (!f->Write(scratchString.c_str()))
+	{
+		return false;
+	}
+
+	scratchString.printf(" O%d:%d:%d:%d", (int)linesPerSpool[A_AXIS], (int)linesPerSpool[B_AXIS], (int)linesPerSpool[C_AXIS], (int)linesPerSpool[D_AXIS]);
+	if (!f->Write(scratchString.c_str()))
+	{
+		return false;
+	}
+
+	scratchString.printf(" L%d:%d:%d:%d", (int)motorGearTeeth[A_AXIS], (int)motorGearTeeth[B_AXIS], (int)motorGearTeeth[C_AXIS], (int)motorGearTeeth[D_AXIS]);
+	if (!f->Write(scratchString.c_str()))
+	{
+		return false;
+	}
+
+	scratchString.printf(" H%d:%d:%d:%d", (int)spoolGearTeeth[A_AXIS], (int)spoolGearTeeth[B_AXIS], (int)spoolGearTeeth[C_AXIS], (int)spoolGearTeeth[D_AXIS]);
+	if (!f->Write(scratchString.c_str()))
+	{
+		return false;
+	}
+
+	scratchString.printf(" J%d:%d:%d:%d", (int)fullStepsPerMotorRev[A_AXIS], (int)fullStepsPerMotorRev[B_AXIS], (int)fullStepsPerMotorRev[C_AXIS], (int)fullStepsPerMotorRev[D_AXIS]);
+	return f->Write(scratchString.c_str());
 }
 
 // Write any calibration data that we need to resume a print after power fail, returning true if successful

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -52,6 +52,7 @@ protected:
 
 private:
 	// Basic facts about movement system
+	const char* ANCHOR_CHARS = "ABCD";
 	static constexpr size_t HANGPRINTER_AXES = 4;
 	static constexpr size_t A_AXIS = 0;
 	static constexpr size_t B_AXIS = 1;

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -52,8 +52,8 @@ protected:
 
 private:
 	// Basic facts about movement system
-	const char* ANCHOR_CHARS = "ABCDEF";
-	static constexpr size_t HANGPRINTER_MAX_AXES = 6;
+	const char* ANCHOR_CHARS = "ABCDEFH"; // Skip the G, since it is reserved in G-code
+	static constexpr size_t HANGPRINTER_MAX_AXES = 7;
 	static constexpr size_t A_AXIS = 0;
 	static constexpr size_t B_AXIS = 1;
 	static constexpr size_t C_AXIS = 2;

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -20,7 +20,7 @@ public:
 
 	// Overridden base class functions. See Kinematics.h for descriptions.
 	const char *GetName(bool forStatusReport) const noexcept override;
-	bool Configure(unsigned int mCode, GCodeBuffer& gb, const StringRef& reply, bool& error) THROWS(GCodeException) override;
+	bool Configure(unsigned int mCode, GCodeBuffer& gb, const StringRef& reply, OutputBuffer *& buf, bool& error) THROWS(GCodeException) override;
 	bool CartesianToMotorSteps(const float machinePos[], const float stepsPerMm[], size_t numVisibleAxes, size_t numTotalAxes, int32_t motorPos[], bool isCoordinated) const noexcept override;
 	void MotorStepsToCartesian(const int32_t motorPos[], const float stepsPerMm[], size_t numVisibleAxes, size_t numTotalAxes, float machinePos[]) const noexcept override;
 	bool SupportsAutoCalibration() const noexcept override { return true; }

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -50,6 +50,9 @@ protected:
 	OBJECT_MODEL_ARRAY(anchors)
 	OBJECT_MODEL_ARRAY(anchorCoordinates)
 
+	bool IsReachablePyramid(float axesCoords[MaxAxes], AxesBitmap axes) const noexcept;
+	bool IsReachablePrism(float axesCoords[MaxAxes], AxesBitmap axes) const noexcept;
+
 private:
 	// Basic facts about movement system
 	const char* ANCHOR_CHARS = "ABCDEFHIJ"; // Skip the G, since it is reserved in G-code
@@ -58,6 +61,9 @@ private:
 	static constexpr size_t B_AXIS = 1;
 	static constexpr size_t C_AXIS = 2;
 	static constexpr size_t D_AXIS = 3;
+	// LastTopRestDown (default) has a single anchor on top and produces pyramid-shaped printing volumes
+	// AllTop has a all anchors on top and produces prism-shaped printing volumes
+	enum AnchorsSetup {LastTopRestDown, AllTop}; // Allowed setups for placing the anchors
 
 	void Init() noexcept;
 	void Recalc() noexcept;
@@ -69,6 +75,7 @@ private:
 
 	size_t numAnchors;
 	float anchors[HANGPRINTER_MAX_AXES][3];				// XYZ coordinates of the anchors
+	AnchorsSetup anchorsSetup;
 	float printRadius;
 	// Line buildup compensation
 	float spoolBuildupFactor;

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -52,8 +52,8 @@ protected:
 
 private:
 	// Basic facts about movement system
-	const char* ANCHOR_CHARS = "ABCD";
-	static constexpr size_t HANGPRINTER_AXES = 4;
+	const char* ANCHOR_CHARS = "ABCDE";
+	static constexpr size_t HANGPRINTER_MAX_AXES = 5;
 	static constexpr size_t A_AXIS = 0;
 	static constexpr size_t B_AXIS = 1;
 	static constexpr size_t C_AXIS = 2;
@@ -67,16 +67,17 @@ private:
 
 	void PrintParameters(const StringRef& reply) const noexcept;									// Print all the parameters for debugging
 
-	float anchors[HANGPRINTER_AXES][3];				// XYZ coordinates of the anchors
+	size_t numAnchors;
+	float anchors[HANGPRINTER_MAX_AXES][3];				// XYZ coordinates of the anchors
 	float printRadius;
 	// Line buildup compensation
 	float spoolBuildupFactor;
-	float spoolRadii[HANGPRINTER_AXES];
-	uint32_t mechanicalAdvantage[HANGPRINTER_AXES], linesPerSpool[HANGPRINTER_AXES];
-	uint32_t motorGearTeeth[HANGPRINTER_AXES], spoolGearTeeth[HANGPRINTER_AXES], fullStepsPerMotorRev[HANGPRINTER_AXES];
+	float spoolRadii[HANGPRINTER_MAX_AXES];
+	uint32_t mechanicalAdvantage[HANGPRINTER_MAX_AXES], linesPerSpool[HANGPRINTER_MAX_AXES];
+	uint32_t motorGearTeeth[HANGPRINTER_MAX_AXES], spoolGearTeeth[HANGPRINTER_MAX_AXES], fullStepsPerMotorRev[HANGPRINTER_MAX_AXES];
 
 	// Derived parameters
-	float k0[HANGPRINTER_AXES], spoolRadiiSq[HANGPRINTER_AXES], k2[HANGPRINTER_AXES], lineLengthsOrigin[HANGPRINTER_AXES];
+	float k0[HANGPRINTER_MAX_AXES], spoolRadiiSq[HANGPRINTER_MAX_AXES], k2[HANGPRINTER_MAX_AXES], lineLengthsOrigin[HANGPRINTER_MAX_AXES];
 	float printRadiusSquared;
 
 #if DUAL_CAN

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -52,8 +52,8 @@ protected:
 
 private:
 	// Basic facts about movement system
-	const char* ANCHOR_CHARS = "ABCDEFHI"; // Skip the G, since it is reserved in G-code
-	static constexpr size_t HANGPRINTER_MAX_AXES = 8;
+	const char* ANCHOR_CHARS = "ABCDEFHIJ"; // Skip the G, since it is reserved in G-code
+	static constexpr size_t HANGPRINTER_MAX_AXES = 9;
 	static constexpr size_t A_AXIS = 0;
 	static constexpr size_t B_AXIS = 1;
 	static constexpr size_t C_AXIS = 2;

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -52,8 +52,8 @@ protected:
 
 private:
 	// Basic facts about movement system
-	const char* ANCHOR_CHARS = "ABCDE";
-	static constexpr size_t HANGPRINTER_MAX_AXES = 5;
+	const char* ANCHOR_CHARS = "ABCDEF";
+	static constexpr size_t HANGPRINTER_MAX_AXES = 6;
 	static constexpr size_t A_AXIS = 0;
 	static constexpr size_t B_AXIS = 1;
 	static constexpr size_t C_AXIS = 2;

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -52,8 +52,8 @@ protected:
 
 private:
 	// Basic facts about movement system
-	const char* ANCHOR_CHARS = "ABCDEFH"; // Skip the G, since it is reserved in G-code
-	static constexpr size_t HANGPRINTER_MAX_AXES = 7;
+	const char* ANCHOR_CHARS = "ABCDEFHI"; // Skip the G, since it is reserved in G-code
+	static constexpr size_t HANGPRINTER_MAX_AXES = 8;
 	static constexpr size_t A_AXIS = 0;
 	static constexpr size_t B_AXIS = 1;
 	static constexpr size_t C_AXIS = 2;

--- a/src/Movement/Kinematics/Kinematics.h
+++ b/src/Movement/Kinematics/Kinematics.h
@@ -94,7 +94,7 @@ public:
 	// If errors were discovered while processing parameters, put an appropriate error message in 'reply' and set 'error' to true.
 	// If no relevant parameters are found, print the existing ones to 'reply' and return false.
 	// If 'mCode' does not apply to this kinematics, call the base class version of this function, which will print a suitable error message.
-	virtual bool Configure(unsigned int mCode, GCodeBuffer& gb, const StringRef& reply, bool& error) THROWS(GCodeException);
+	virtual bool Configure(unsigned int mCode, GCodeBuffer& gb, const StringRef& reply, OutputBuffer *& buf, bool& error) THROWS(GCodeException);
 
 	// Convert Cartesian coordinates to motor positions measured in steps from reference position
 	// 'machinePos' is a set of axis and extruder positions to convert


### PR DESCRIPTION
This allows the hangprinter kynematics to be configured with more than 4 anchors/motors, up to 9 at a maximum.
I don't know if allowing more anchors would be possible, but I'm assuming 9 is the maximum because M584 can only map XYZUVWABC. 
I personally want to use 8 anchors for my little project (https://github.com/jtimon/reprope) and perhaps nobody will ever want to 
use 9 anchors to begin with, so I don't think it would make sense to go further than this, in principle.

With 4 anchors you get a tetahedron printing volume.
With 5 anchors, you get a squared pyramid printing volume.
With 6 anchors, a pentagonal pyramid.
With 7, hexagonal pyramid
etc.

This still assumes one anchor on the top and the rest bellow the bed. But I plan to create another PR exploring allowing other anchor positions and thus other printing volume shapes.

So far this is completely untested.
I separated the additions of an extra anchor/motor so that we can perhaps merge things as we test them.
Of course, assuming there's not something terribly wrong with this that I'm not aware of.
We should test:

- That a regular 4 anchor hangprinter keeps working exactly the same
- That a 5 anchor hangprinter works
- That a 6 anchor hangprinter works
- etc

But I can always squash as preferred or separate things differently if it is preferred.

Note: the MotorStepsToCartesian could have less error if all the anchors were used instead of just 4 of them for all cases, but that requires much more work.

#584 being merged first would make this diff a little bit smaller.
Dependencies:

- [ ] https://github.com/Duet3D/RepRapFirmware/pull/584