### PR TITLE
3.5 NOCHANGE: Hangprinter: simplify things by turning unrolled stuff into loops

### DIFF
--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -532,69 +532,79 @@ AxesBitmap HangprinterKinematics::MustBeHomedAxes(AxesBitmap axesMoving, bool di
 // Write the parameters to a file, returning true if success
 bool HangprinterKinematics::WriteCalibrationParameters(FileStore *f) const noexcept
 {
-	bool ok = f->Write("; Hangprinter parameters\n");
-	if (ok)
+	bool ok = false;
+	String<255> scratchString;
+
+	scratchString.printf("; Hangprinter parameters\n");
+	scratchString.printf("M669 K6 ");
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	for (size_t i = 0; i < HANGPRINTER_AXES; ++i)
 	{
-		String<100> scratchString;
-		scratchString.printf("M669 K6 A%.3f:%.3f:%.3f B%.3f:%.3f:%.3f",
-							(double)anchors[A_AXIS][X_AXIS], (double)anchors[A_AXIS][Y_AXIS], (double)anchors[A_AXIS][Z_AXIS],
-							(double)anchors[B_AXIS][X_AXIS], (double)anchors[B_AXIS][Y_AXIS], (double)anchors[B_AXIS][Z_AXIS]);
-		ok = f->Write(scratchString.c_str());
-		if (ok)
-		{
-			scratchString.printf(" C%.3f:%.3f:%.3f D%.3f:%.3f:%.3f P%.1f\n",
-								(double)anchors[C_AXIS][X_AXIS], (double)anchors[C_AXIS][Y_AXIS], (double)anchors[C_AXIS][Z_AXIS],
-								(double)anchors[D_AXIS][X_AXIS], (double)anchors[D_AXIS][Y_AXIS], (double)anchors[D_AXIS][Z_AXIS],
-								(double)printRadius);
-			ok = f->Write(scratchString.c_str());
-			if (ok)
-			{
-				scratchString.printf("M666 Q%.6f R%.3f:%.3f:%.3f:%.3f U%d:%d:%d:%d",
-									(double)spoolBuildupFactor, (double)spoolRadii[A_AXIS],
-									(double)spoolRadii[B_AXIS], (double)spoolRadii[C_AXIS], (double)spoolRadii[D_AXIS],
-									(int)mechanicalAdvantage[A_AXIS], (int)mechanicalAdvantage[B_AXIS],
-									(int)mechanicalAdvantage[C_AXIS], (int)mechanicalAdvantage[D_AXIS]
-						);
-				ok = f->Write(scratchString.c_str());
-				if (ok)
-				{
-					scratchString.printf(" O%d:%d:%d:%d L%d:%d:%d:%d H%d:%d:%d:%d J%d:%d:%d:%d",
-										(int)linesPerSpool[A_AXIS], (int)linesPerSpool[B_AXIS],
-										(int)linesPerSpool[C_AXIS], (int)linesPerSpool[D_AXIS],
-										(int)motorGearTeeth[A_AXIS], (int)motorGearTeeth[B_AXIS],
-										(int)motorGearTeeth[C_AXIS], (int)motorGearTeeth[D_AXIS],
-										(int)spoolGearTeeth[A_AXIS], (int)spoolGearTeeth[B_AXIS],
-										(int)spoolGearTeeth[C_AXIS], (int)spoolGearTeeth[D_AXIS],
-										(int)fullStepsPerMotorRev[A_AXIS], (int)fullStepsPerMotorRev[B_AXIS],
-										(int)fullStepsPerMotorRev[C_AXIS], (int)fullStepsPerMotorRev[D_AXIS]
-							);
-					ok = f->Write(scratchString.c_str());
-					if (ok)
-					{
-						scratchString.printf(" W%.2f S%.2f I%.1f:%.1f:%.1f:%.1f X%.1f:%.1f:%.1f:%.1f",
-							(double)moverWeight_kg, (double)springKPerUnitLength,
-							(double)minPlannedForce_Newton[A_AXIS], (double)minPlannedForce_Newton[B_AXIS],
-							(double)minPlannedForce_Newton[C_AXIS], (double)minPlannedForce_Newton[D_AXIS],
-							(double)maxPlannedForce_Newton[A_AXIS], (double)maxPlannedForce_Newton[B_AXIS],
-							(double)maxPlannedForce_Newton[C_AXIS], (double)maxPlannedForce_Newton[D_AXIS]
-						);
-						ok = f->Write(scratchString.c_str());
-						if (ok)
-						{
-							scratchString.printf(" Y%.1f:%.1f:%.1f:%.1f T%.1f C%.4f:%.4f:%.4f:%.4f\n",
-								(double)guyWireLengths[A_AXIS], (double)guyWireLengths[B_AXIS],
-								(double)guyWireLengths[C_AXIS], (double)guyWireLengths[D_AXIS],
-								(double)targetForce_Newton,
-								(double)torqueConstants[A_AXIS], (double)torqueConstants[B_AXIS],
-								(double)torqueConstants[C_AXIS], (double)torqueConstants[D_AXIS]
-							);
-							ok = f->Write(scratchString.c_str());
-						}
-					}
-				}
-			}
-		}
+		scratchString.catf("%c%.3f:%.3f:%.3f ", ANCHOR_CHARS[i], (double)anchors[i][X_AXIS], (double)anchors[i][Y_AXIS], (double)anchors[i][Z_AXIS]);
 	}
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" P%.1f", (double)printRadius);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf("M666 Q%.6f ", (double)spoolBuildupFactor);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf("R%.3f:%.3f:%.3f:%.3f", (double)spoolRadii[A_AXIS], (double)spoolRadii[B_AXIS], (double)spoolRadii[C_AXIS], (double)spoolRadii[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf("U%d:%d:%d:%d", (int)mechanicalAdvantage[A_AXIS], (int)mechanicalAdvantage[B_AXIS], (int)mechanicalAdvantage[C_AXIS], (int)mechanicalAdvantage[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" O%d:%d:%d:%d", (int)linesPerSpool[A_AXIS], (int)linesPerSpool[B_AXIS], (int)linesPerSpool[C_AXIS], (int)linesPerSpool[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" L%d:%d:%d:%d", (int)motorGearTeeth[A_AXIS], (int)motorGearTeeth[B_AXIS], (int)motorGearTeeth[C_AXIS], (int)motorGearTeeth[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" H%d:%d:%d:%d", (int)motorGearTeeth[A_AXIS], (int)motorGearTeeth[B_AXIS], (int)motorGearTeeth[C_AXIS], (int)motorGearTeeth[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" J%d:%d:%d:%d", (int)fullStepsPerMotorRev[A_AXIS], (int)fullStepsPerMotorRev[B_AXIS], (int)fullStepsPerMotorRev[C_AXIS], (int)fullStepsPerMotorRev[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" W%.2f S%.2f", (double)moverWeight_kg, (double)springKPerUnitLength);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" I%.1f:%.1f:%.1f:%.1f",
+		(double)minPlannedForce_Newton[A_AXIS], (double)minPlannedForce_Newton[B_AXIS], (double)minPlannedForce_Newton[C_AXIS], (double)minPlannedForce_Newton[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" X%.1f:%.1f:%.1f:%.1f",
+		(double)maxPlannedForce_Newton[A_AXIS], (double)maxPlannedForce_Newton[B_AXIS], (double)maxPlannedForce_Newton[C_AXIS], (double)maxPlannedForce_Newton[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" Y%.1f:%.1f:%.1f:%.1f",
+		(double)guyWireLengths[A_AXIS], (double)guyWireLengths[B_AXIS], (double)guyWireLengths[C_AXIS], (double)guyWireLengths[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" T%.1f", (double)targetForce_Newton);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" C%.4f:%.4f:%.4f:%.4f\n", (double)torqueConstants[A_AXIS], (double)torqueConstants[B_AXIS], (double)torqueConstants[C_AXIS], (double)torqueConstants[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+
 	return ok;
 }
 

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -57,6 +57,7 @@ protected:
 
 private:
 	// Basic facts about movement system
+	const char* ANCHOR_CHARS = "ABCD";
 	static constexpr size_t HANGPRINTER_AXES = 4;
 	static constexpr size_t A_AXIS = 0;
 	static constexpr size_t B_AXIS = 1;


### PR DESCRIPTION
This is a rebased version of https://github.com/Duet3D/RepRapFirmware/pull/584 in the 3.4-dev branch.

The main goal is to make it easier to get support for more than 4 anchors in the hangprinter kynematics.
This PR shouldn't change functionality at all. If it does, that's a bug.

Testing status:

Everything seems to work, I still haven't tested the changes in WriteCalibrationParameters()
But not with a real hangprinter, my config is different with 4 anchors on top and not really ready to print anything, just moving the headtool around for now. 
Real hangprinter testers welcomed.

