### PR TITLE
3.5 hangprinter: Allow custom and prism-like setups

### DIFF
--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -532,69 +532,79 @@ AxesBitmap HangprinterKinematics::MustBeHomedAxes(AxesBitmap axesMoving, bool di
 // Write the parameters to a file, returning true if success
 bool HangprinterKinematics::WriteCalibrationParameters(FileStore *f) const noexcept
 {
-	bool ok = f->Write("; Hangprinter parameters\n");
-	if (ok)
+	bool ok = false;
+	String<255> scratchString;
+
+	scratchString.printf("; Hangprinter parameters\n");
+	scratchString.printf("M669 K6 ");
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	for (size_t i = 0; i < HANGPRINTER_AXES; ++i)
 	{
-		String<100> scratchString;
-		scratchString.printf("M669 K6 A%.3f:%.3f:%.3f B%.3f:%.3f:%.3f",
-							(double)anchors[A_AXIS][X_AXIS], (double)anchors[A_AXIS][Y_AXIS], (double)anchors[A_AXIS][Z_AXIS],
-							(double)anchors[B_AXIS][X_AXIS], (double)anchors[B_AXIS][Y_AXIS], (double)anchors[B_AXIS][Z_AXIS]);
-		ok = f->Write(scratchString.c_str());
-		if (ok)
-		{
-			scratchString.printf(" C%.3f:%.3f:%.3f D%.3f:%.3f:%.3f P%.1f\n",
-								(double)anchors[C_AXIS][X_AXIS], (double)anchors[C_AXIS][Y_AXIS], (double)anchors[C_AXIS][Z_AXIS],
-								(double)anchors[D_AXIS][X_AXIS], (double)anchors[D_AXIS][Y_AXIS], (double)anchors[D_AXIS][Z_AXIS],
-								(double)printRadius);
-			ok = f->Write(scratchString.c_str());
-			if (ok)
-			{
-				scratchString.printf("M666 Q%.6f R%.3f:%.3f:%.3f:%.3f U%d:%d:%d:%d",
-									(double)spoolBuildupFactor, (double)spoolRadii[A_AXIS],
-									(double)spoolRadii[B_AXIS], (double)spoolRadii[C_AXIS], (double)spoolRadii[D_AXIS],
-									(int)mechanicalAdvantage[A_AXIS], (int)mechanicalAdvantage[B_AXIS],
-									(int)mechanicalAdvantage[C_AXIS], (int)mechanicalAdvantage[D_AXIS]
-						);
-				ok = f->Write(scratchString.c_str());
-				if (ok)
-				{
-					scratchString.printf(" O%d:%d:%d:%d L%d:%d:%d:%d H%d:%d:%d:%d J%d:%d:%d:%d",
-										(int)linesPerSpool[A_AXIS], (int)linesPerSpool[B_AXIS],
-										(int)linesPerSpool[C_AXIS], (int)linesPerSpool[D_AXIS],
-										(int)motorGearTeeth[A_AXIS], (int)motorGearTeeth[B_AXIS],
-										(int)motorGearTeeth[C_AXIS], (int)motorGearTeeth[D_AXIS],
-										(int)spoolGearTeeth[A_AXIS], (int)spoolGearTeeth[B_AXIS],
-										(int)spoolGearTeeth[C_AXIS], (int)spoolGearTeeth[D_AXIS],
-										(int)fullStepsPerMotorRev[A_AXIS], (int)fullStepsPerMotorRev[B_AXIS],
-										(int)fullStepsPerMotorRev[C_AXIS], (int)fullStepsPerMotorRev[D_AXIS]
-							);
-					ok = f->Write(scratchString.c_str());
-					if (ok)
-					{
-						scratchString.printf(" W%.2f S%.2f I%.1f:%.1f:%.1f:%.1f X%.1f:%.1f:%.1f:%.1f",
-							(double)moverWeight_kg, (double)springKPerUnitLength,
-							(double)minPlannedForce_Newton[A_AXIS], (double)minPlannedForce_Newton[B_AXIS],
-							(double)minPlannedForce_Newton[C_AXIS], (double)minPlannedForce_Newton[D_AXIS],
-							(double)maxPlannedForce_Newton[A_AXIS], (double)maxPlannedForce_Newton[B_AXIS],
-							(double)maxPlannedForce_Newton[C_AXIS], (double)maxPlannedForce_Newton[D_AXIS]
-						);
-						ok = f->Write(scratchString.c_str());
-						if (ok)
-						{
-							scratchString.printf(" Y%.1f:%.1f:%.1f:%.1f T%.1f C%.4f:%.4f:%.4f:%.4f\n",
-								(double)guyWireLengths[A_AXIS], (double)guyWireLengths[B_AXIS],
-								(double)guyWireLengths[C_AXIS], (double)guyWireLengths[D_AXIS],
-								(double)targetForce_Newton,
-								(double)torqueConstants[A_AXIS], (double)torqueConstants[B_AXIS],
-								(double)torqueConstants[C_AXIS], (double)torqueConstants[D_AXIS]
-							);
-							ok = f->Write(scratchString.c_str());
-						}
-					}
-				}
-			}
-		}
+		scratchString.catf("%c%.3f:%.3f:%.3f ", ANCHOR_CHARS[i], (double)anchors[i][X_AXIS], (double)anchors[i][Y_AXIS], (double)anchors[i][Z_AXIS]);
 	}
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" P%.1f", (double)printRadius);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf("M666 Q%.6f ", (double)spoolBuildupFactor);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf("R%.3f:%.3f:%.3f:%.3f", (double)spoolRadii[A_AXIS], (double)spoolRadii[B_AXIS], (double)spoolRadii[C_AXIS], (double)spoolRadii[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf("U%d:%d:%d:%d", (int)mechanicalAdvantage[A_AXIS], (int)mechanicalAdvantage[B_AXIS], (int)mechanicalAdvantage[C_AXIS], (int)mechanicalAdvantage[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" O%d:%d:%d:%d", (int)linesPerSpool[A_AXIS], (int)linesPerSpool[B_AXIS], (int)linesPerSpool[C_AXIS], (int)linesPerSpool[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" L%d:%d:%d:%d", (int)motorGearTeeth[A_AXIS], (int)motorGearTeeth[B_AXIS], (int)motorGearTeeth[C_AXIS], (int)motorGearTeeth[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" H%d:%d:%d:%d", (int)motorGearTeeth[A_AXIS], (int)motorGearTeeth[B_AXIS], (int)motorGearTeeth[C_AXIS], (int)motorGearTeeth[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" J%d:%d:%d:%d", (int)fullStepsPerMotorRev[A_AXIS], (int)fullStepsPerMotorRev[B_AXIS], (int)fullStepsPerMotorRev[C_AXIS], (int)fullStepsPerMotorRev[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" W%.2f S%.2f", (double)moverWeight_kg, (double)springKPerUnitLength);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" I%.1f:%.1f:%.1f:%.1f",
+		(double)minPlannedForce_Newton[A_AXIS], (double)minPlannedForce_Newton[B_AXIS], (double)minPlannedForce_Newton[C_AXIS], (double)minPlannedForce_Newton[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" X%.1f:%.1f:%.1f:%.1f",
+		(double)maxPlannedForce_Newton[A_AXIS], (double)maxPlannedForce_Newton[B_AXIS], (double)maxPlannedForce_Newton[C_AXIS], (double)maxPlannedForce_Newton[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" Y%.1f:%.1f:%.1f:%.1f",
+		(double)guyWireLengths[A_AXIS], (double)guyWireLengths[B_AXIS], (double)guyWireLengths[C_AXIS], (double)guyWireLengths[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" T%.1f", (double)targetForce_Newton);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" C%.4f:%.4f:%.4f:%.4f\n", (double)torqueConstants[A_AXIS], (double)torqueConstants[B_AXIS], (double)torqueConstants[C_AXIS], (double)torqueConstants[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+
 	return ok;
 }
 

--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -444,17 +444,27 @@ static bool isSameSide(float const v0[3], float const v1[3], float const v2[3], 
 	return dot0*dot1 > 0.0F;
 }
 
-static bool isInsideTetrahedron(float const point[3], float const tetrahedron[4][3]){
-	return isSameSide(tetrahedron[0], tetrahedron[1], tetrahedron[2], tetrahedron[3], point) &&
-	       isSameSide(tetrahedron[2], tetrahedron[1], tetrahedron[3], tetrahedron[0], point) &&
-	       isSameSide(tetrahedron[2], tetrahedron[3], tetrahedron[0], tetrahedron[1], point) &&
-	       isSameSide(tetrahedron[0], tetrahedron[3], tetrahedron[1], tetrahedron[2], point);
-}
-
+// For each triangle side in a pseudo-pyramid, check if the point is inside the pyramid (Except for the base)
+// Also check that any point below the line between two exterior anchors (all anchors are exterior except for the last one)
+// is in the "inside part" all the way down to min_Z, however low it may be.
+// To further limit the movements in the X and Y axes one can simply set a smaller print radius.
 bool HangprinterKinematics::IsReachable(float axesCoords[MaxAxes], AxesBitmap axes) const noexcept /*override*/
 {
 	float const coords[3] = {axesCoords[X_AXIS], axesCoords[Y_AXIS], axesCoords[Z_AXIS]};
-	return isInsideTetrahedron(coords, anchors);
+	bool reachable = true;
+
+	// Check all the planes defined by triangle sides in the pyramid
+	for (size_t i = 0; reachable && i < HANGPRINTER_AXES - 1; ++i) {
+		reachable = reachable && isSameSide(anchors[i], anchors[(i+1) % (HANGPRINTER_AXES - 1)], anchors[HANGPRINTER_AXES - 1], anchors[(i+2) % (HANGPRINTER_AXES - 1)], coords);
+	}
+
+	// For each side of the base, check the plane formed by side and another point bellow them in z.
+	for (size_t i = 0; reachable && i < HANGPRINTER_AXES - 1; ++i) {
+		float const lower_point[3] = {anchors[i][0], anchors[i][1], anchors[i][2] - 1};
+		reachable = reachable && isSameSide(anchors[i], anchors[(i+1) % (HANGPRINTER_AXES - 1)], lower_point, anchors[(i+2) % (HANGPRINTER_AXES - 1)], coords);
+	}
+
+	return reachable;
 }
 
 // Limit the Cartesian position that the user wants to move to returning true if we adjusted the position

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -12,6 +12,13 @@
 
 #if SUPPORT_HANGPRINTER
 
+// Different modes can be configured for different tradeoffs in terms of printing volumes and speeds
+enum class HangprinterAnchorMode {
+	None, // All is reacheable in None anchor mode as printing volume
+	LastOnTop, // (Default) Rsults in a pyramid plus a prism below if the lower anchors are above the printing bed
+	AllOnTop, // Result in a prism (speeds get limited, specially going down in Z)
+};
+
 class HangprinterKinematics : public RoundBedKinematics
 {
 public:
@@ -55,6 +62,9 @@ public:
 protected:
 	DECLARE_OBJECT_MODEL_WITH_ARRAYS
 
+	bool IsInsidePyramidSides(float const coords[3]) const noexcept;
+	bool IsInsidePrismSides(float const coords[3], unsigned const discount_last) const noexcept;
+
 private:
 	// Basic facts about movement system
 	const char* ANCHOR_CHARS = "ABCD";
@@ -72,6 +82,7 @@ private:
 	void PrintParameters(const StringRef& reply) const noexcept;			// Print all the parameters for debugging
 
 	// The real defaults are in the cpp file
+	HangprinterAnchorMode anchorMode = HangprinterAnchorMode::LastOnTop;
 	float printRadius = 0.0F;
 	float anchors[HANGPRINTER_AXES][3] = {{ 0.0, 0.0, 0.0},
 	                                      { 0.0, 0.0, 0.0},

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -57,6 +57,7 @@ protected:
 
 private:
 	// Basic facts about movement system
+	const char* ANCHOR_CHARS = "ABCD";
 	static constexpr size_t HANGPRINTER_AXES = 4;
 	static constexpr size_t A_AXIS = 0;
 	static constexpr size_t B_AXIS = 1;


### PR DESCRIPTION
In addition to allow any pseudo-pyramid as in #598 which this PR depends on, this allows to setup hangprinters without a middle anchor. 

This doesn't require any extra anchors. One could, for example, set each of the 4 anchors in one top corner of a room, resulting in a quadrangular prism printing volume. Or it could be used to move cameras in stadiums and whatnot.

For that we just set all the anchors on top.
It also allows a "None" anchor mode which always IsReacheable always returns true, which is interesting for people experimenting with potential future modes not contemplated yet, like halfTop-halfDown setups.   

Dependencies:

- [ ] 3.5 Hangprinter: Generalize IsReachable() to any pseudo-pyramid #598
- [ ]  3.5 NOCHANGE: hangprinter: simplify things by turning unrolled stuff into loops #597 

Outdated
~~
Two options come to mind:

A) Allow users to manually select it by adding some parameter in M669. If we chose this option, any suggestion?
B) Calculate whether the last anchor is "in the middle" or not. Probably I should explain with code what I mean by "in the middle" rather than trying it in english to avoid misunderstandings.
~~