### PR TITLE
3.5-dev-DotStarConfig

### DIFF
--- a/src/LedStrips/DotStarLedStrip.cpp
+++ b/src/LedStrips/DotStarLedStrip.cpp
@@ -21,10 +21,10 @@ GCodeResult DotStarLedStrip::Configure(GCodeBuffer& gb, const StringRef& reply, 
 	bool seen = false;
 	GCodeResult rslt = CommonConfigure(gb, reply, pinName, seen);
 
-	if (gb.Seen('V'))
+	if (gb.Seen('K'))
 	{
 		uint32_t order;
-		gb.TryGetLimitedUIValue('V', order, seen, (uint32_t)ColorOrder::count);
+		gb.TryGetLimitedUIValue('K', order, seen, (uint32_t)ColorOrder::count);
 		colorOrder = (ColorOrder)order;
 	}
 

--- a/src/LedStrips/DotStarLedStrip.h
+++ b/src/LedStrips/DotStarLedStrip.h
@@ -15,6 +15,17 @@
 class DotStarLedStrip : public LocalLedStrip
 {
 public:
+	enum class ColorOrder : uint8_t
+	{
+		BGR = 0,
+		BRG,
+		RGB,
+		RBG,
+		GBR,
+		GRB,
+		count
+	};
+
 	DotStarLedStrip() noexcept;
 
 	GCodeResult Configure(GCodeBuffer& gb, const StringRef& reply, const char *_ecv_array pinName) THROWS(GCodeException) override;
@@ -36,6 +47,7 @@ private:
 	unsigned int numRemaining = 0;											// how much of the current request remains after the current transfer
 	unsigned int totalSent = 0;												// total amount of data sent since the start frame
 	bool needStartFrame = true;
+	ColorOrder colorOrder;
 };
 
 #endif


### PR DESCRIPTION
Add colour order config to `M950` for DotStar LEDs to support chips that do not use BGR colour order

K = 0 (BGR), 1 (BRG), 2 (RGB), 3 (RBG), 4 (GBR), 5 (GRB)

