### PR TITLE
Fix #1146 (maybe)

### DIFF
--- a/src/GCodes/GCodes4.cpp
+++ b/src/GCodes/GCodes4.cpp
@@ -1564,7 +1564,7 @@ void GCodes::RunStateMachine(GCodeBuffer& gb, const StringRef& reply) noexcept
 			}
 			else
 			{
-				ms.currentTool->SetOffset(Z_AXIS, -g30zHeightError, true);
+				ms.currentTool->SetOffset(Z_AXIS, platform.GetZProbeOrDefault(currentZProbeNumber)->GetLastStoppedHeight(), true);
 				ToolOffsetInverseTransform(ms);			// update user coordinates to reflect the new tool offset
 			}
 		}


### PR DESCRIPTION
I did not fully understand `g30zHeightError` (yet). But this implementation seems a better fit for what the docs claim. It is analogue to the `G30SValue == -3` branch. 

Unfortunately, the build process is very complicated and requires system level installs, so I can't test this in reasonable time/effort. :-/