### PR TITLE
Add serial parity option (M575 F) for device/Modbus mode

### DIFF
--- a/src/Comms/AuxDevice.cpp
+++ b/src/Comms/AuxDevice.cpp
@@ -42,7 +42,10 @@ void AuxDevice::SetMode(AuxMode p_mode) noexcept
 #if SUPPORT_MODBUS_RTU
 			uart->SetOnTxEndedCallback((p_mode == AuxMode::device) ? GlobalTxEndedCallback : nullptr, CallbackParameter(this));
 #endif
-			uart->begin(baudRate);
+			AsyncSerial::UARTModes config = AsyncSerial::Mode_8N1;
+			if (serialParity == SerialParity::even) { config = AsyncSerial::Mode_8E1; }
+			else if (serialParity == SerialParity::odd) { config = AsyncSerial::Mode_8O1; }
+			uart->begin(baudRate, config);
 			mode = p_mode;
 		}
 	}

--- a/src/Comms/AuxDevice.h
+++ b/src/Comms/AuxDevice.h
@@ -31,11 +31,14 @@ class AsyncSerial;
 class AuxDevice
 {
 public:
+	enum class SerialParity : uint8_t { none = 0, even, odd };
+
 	AuxDevice() noexcept;
 
 	void Init(AsyncSerial *p_uart, uint32_t p_baudRate) noexcept;
 	bool IsEnabledForGCodeIo() const noexcept { return mode == AuxMode::raw || mode == AuxMode::panelDue; }
 	void SetMode(AuxMode p_mode) noexcept;
+	void SetSerialParity(SerialParity p_parity) noexcept { serialParity = p_parity; }	// applied on next SetMode; affects device/Modbus mode only
 	void SetBaudRate(uint32_t p_baudRate) noexcept { baudRate = p_baudRate; }			// must call SetMode after calling this to actually change the baud rate
 	void Disable() noexcept;
 	AuxMode GetMode() const noexcept { return mode; }
@@ -90,6 +93,8 @@ private:
 	uint32_t seq;							// sequence number for output in PanelDue mode
 	uint32_t baudRate;
 	AuxMode mode = AuxMode::disabled;		// whether disabled, raw, PanelDue mode or Modbus RTU mode
+
+	SerialParity serialParity = SerialParity::none;		// device/Modbus serial parity: none=8N1, even=8E1, odd=8O1
 
 #if SUPPORT_MODBUS_RTU
 	IoPort txNotRx;							// port used to switch the RS485 port between transmit and receive

--- a/src/Platform/Platform.cpp
+++ b/src/Platform/Platform.cpp
@@ -2303,6 +2303,14 @@ GCodeResult Platform::HandleM575(GCodeBuffer& gb, const StringRef& reply) THROWS
 				}
 			}
 #  endif
+			// Serial parity for device/Modbus mode. Always applied so that omitting F restores
+			// the pre-existing behaviour (no parity, 8N1) rather than keeping a previous setting.
+			switch (gb.Seen('F') ? gb.GetLimitedUIValue('F', 3) : 0)
+			{
+			case 1:		dev.SetSerialParity(AuxDevice::SerialParity::even); break;
+			case 2:		dev.SetSerialParity(AuxDevice::SerialParity::odd); break;
+			default:	dev.SetSerialParity(AuxDevice::SerialParity::none); break;
+			}
 # endif
 		}
 


### PR DESCRIPTION
Implements #1196 (parity bit for RS485 Modbus).

## What's changed

Aux serial ports in device (Modbus RTU) mode previously always opened as 8N1. Some Modbus devices require parity — e.g. OnRobot grippers need 8E1 — so this adds an optional parity setting to M575:

- **`AuxDevice`**: stores a `SerialParity` (none/even/odd) and applies it in `SetMode()` by selecting `Mode_8N1`/`8E1`/`8O1` when calling `AsyncSerial::begin(baudRate, config)`.
- **`M575`**: in device mode, parses a new `F` parameter — `F0` none/8N1 (default), `F1` even/8E1, `F2` odd/8O1. The parameter is applied on every device-mode M575, so omitting `F` gives 8N1 exactly as before this option existed, rather than retaining a previously set parity.

Example: `M575 P1 S7 B115200 F1` → Modbus RTU, 115200 baud, 8E1.

## Notes

- No core change needed: CoreN2G's `AsyncSerial` already defines the `Mode_8E1`/`8O1` framing constants.
- Default stays 8N1, so PanelDue/raw modes are unaffected.
- `F` doesn't clash with any existing M575 parameter.
- Parity is bus-wide (as suggested in the issue); per-slave parity via M260/M261 is not included in this PR.
- I've been running this in production on 3.6.2-based builds integrating an OnRobot gripper (8E1); this PR is the same change rebased onto 3.7-dev.