### PR TITLE
Fix the USE_EMBEDDED_FILES build

### DIFF
--- a/src/Networking/ESP8266WiFi/WiFiInterface.cpp
+++ b/src/Networking/ESP8266WiFi/WiFiInterface.cpp
@@ -1136,6 +1136,7 @@ bool WiFiInterface::ImportTlsFromSd(const StringRef& reply) noexcept
 
 	supportsTls = true;
 
+#if HAS_MASS_STORAGE || HAS_SBC_INTERFACE
 	// Securely delete the SD copies - they now live in ESP flash
 	String<MaxFilenameLength> path;
 	path.copy(TlsCertFile);
@@ -1144,6 +1145,10 @@ bool WiFiInterface::ImportTlsFromSd(const StringRef& reply) noexcept
 	(void)MassStorage::SecureDelete(path.GetRef(), ErrorMessageMode::messageAlways);
 
 	reply.copy("TLS cert/key imported to WiFi module flash; SD copies wiped and deleted");
+#else
+	// The source is a read-only embedded filesystem, so there is nothing to delete afterwards.
+	reply.copy("TLS cert/key imported to WiFi module flash");
+#endif
 	return true;
 }
 

--- a/src/Networking/LwipEthernet/LwipEthernetInterface.cpp
+++ b/src/Networking/LwipEthernet/LwipEthernetInterface.cpp
@@ -856,6 +856,7 @@ GCodeResult LwipEthernetInterface::EnableInterface(int mode, const StringRef& ss
 	// Only honoured while the interface is down, matching the documented rule
 	if (tlsParam < 0 && !activated)
 	{
+#if HAS_MASS_STORAGE || HAS_SBC_INTERFACE
 		bool wiped = false;
 		String<MaxFilenameLength> path;
 		path.copy(TlsCertFile);
@@ -872,6 +873,10 @@ GCodeResult LwipEthernetInterface::EnableInterface(int mode, const StringRef& ss
 		{
 			platform.Message(NetworkInfoMessage, "TLS: stored cert/key wiped and deleted from /sys/\n");
 		}
+#else
+		// Nothing to wipe: with an embedded filesystem there is no writable storage to have kept them on.
+		platform.Message(NetworkInfoMessage, "TLS: no writable storage, nothing to wipe\n");
+#endif
 	}
 	const bool tlsAllowedParam = (tlsParam > 0);
 #else


### PR DESCRIPTION
`Pins_Duet3_MB6HC.h` has always had a `USE_EMBEDDED_FILES` branch, but nothing builds it and on `3.7-dev` it does not compile: the TLS code in `LwipEthernetInterface` and `WiFiInterface` calls `MassStorage::SecureDelete`, which is declared only under `HAS_MASS_STORAGE || HAS_SBC_INTERFACE` - both of which `USE_EMBEDDED_FILES` turns off.

Guarded those two blocks with the same condition the declaration uses. An embedded filesystem is read-only, so there is nothing to wipe and the reply now says so instead of the build failing.

`Duet3_MB6HC` is byte-for-byte the same size afterwards, so the guards are inert on that path.

**Testing note:** nothing upstream builds `USE_EMBEDDED_FILES`, so this cannot be exercised without a build config for the embedded variant. I have one at `meeloo/RepRapFirmware:build/embedded-mb6hc-config` and can open it as a separate PR, fold it into this one, or leave it out - whichever suits