### PR TITLE
Add axis following (M604)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,13 @@
 /FMDC_V02_Debug/
 /FMDC_V03/
 /Duet3_MB6HC_no_SD/
+/Duet3_MB6HC_embedded/
 /Duet3_MB6HC_no_S_curve/
-/INDX/
+/tests/build/
 /.clangd
 /.clang-format
 /src/Temp/
-/.settings/
+
+# Build intermediates and editor droppings that have been committed by accident before
+INDX/
+.DS_Store

--- a/Developer-documentation/Axis following (M604).md
+++ b/Developer-documentation/Axis following (M604).md
@@ -1,0 +1,115 @@
+# Axis following — M604
+
+Makes one axis track another **as part of the same coordinated move**, rather than reacting to it.
+
+The motivating case is a Z-independent dust shoe on a U axis: the shoe is carried on the Z carriage,
+so U has to move the opposite way as Z plunges to keep the bristles on the material.
+
+## Command
+
+```
+M604 A"<follower>" B"<leader>" [S<scale>] [O<offset>] [E<0|1>]
+```
+
+| Parameter | Meaning |
+|---|---|
+| `A` | Follower axis letter, quoted. The axis that is driven. |
+| `B` | Leader axis letter, quoted. The axis that is tracked. |
+| `S` | Scale, default **-1**. A follower carried on the leader must move the opposite way to stay put. |
+| `O` | Offset. Normally omit it — see below. |
+| `E` | 1 engages, 0 disengages. |
+| *(none)* | Report state. |
+
+The rule is `follower = S × leader + O`, in **machine coordinates**, clamped to the follower's `M208`
+limits.
+
+```gcode
+M604 A"U" B"Z" E1     ; U now tracks Z
+M604                  ; U follows Z as -1.000 * Z + 70.000, engaged
+M604 E0               ; U becomes an ordinary axis again
+```
+
+## Engaging captures the relationship
+
+**Omit `O`.** When you engage, the offset is computed from where the two axes are *right now*, so
+engaging means "hold the current separation from here on". That is what the G-code implementation
+used `global.dustShoePrevZ` for. Give `O` explicitly only if you want an absolute relationship.
+
+So the sequence is: move the follower where you want it, then engage.
+
+```gcode
+G1 U30 F8000          ; put the shoe where the bristles touch
+M400
+M604 A"U" B"Z" E1     ; hold that relationship
+```
+
+## What you get for free
+
+* **Zero latency.** The follower is derived where a move's target is computed, so it is part of the
+  same move as the leader. Measured skew between the Z and U step trains is 0.0000 ms at the start,
+  middle and end of a move — the planner never sees them as separate axes. This holds for straight
+  moves, arc segments (including helical) and `M700` velocity jogging.
+* **Axis limits.** The follower is clamped to its own `M208` range, which *is* the useful behaviour:
+  the shoe tracks the tool down until it reaches its lower limit, then rests there while Z carries on
+  into the work.
+* **Acceleration and jerk limits.** The follower is a real axis in a real move, so its own `M201`,
+  `M203` and `M566` apply, and lookahead plans it like anything else.
+
+## Homing
+
+Engaging is refused unless the follower axis is homed, matching the check the G-code daemon made.
+Disengaging is always allowed.
+
+## Replacing the G-code implementation
+
+The `daemon.g` tracking loop becomes unnecessary:
+
+```gcode
+; daemon.g - delete the dust shoe section entirely
+var deltaZ = ...
+if {abs(var.deltaZ) > 0.1}
+    G53 G1 U{var.targetU} F8000        ; all of this goes away
+```
+
+`dustShoeEngage.g` keeps its positioning move and gains one line:
+
+```gcode
+G1 U{var.targetU} F8000
+M400
+M604 A"U" B"Z" E1                      ; instead of set global.dustShoeEngaged = true
+```
+
+`dustShoeRetract.g` likewise:
+
+```gcode
+M604 E0                                ; instead of set global.dustShoeEngaged = false
+G53 G1 U{move.axes[3].max} F8000
+```
+
+Keep the engage/retract macros: the engaged height is a machine property that belongs in
+configuration, not in firmware.
+
+## Tool changes
+
+Because the rule is applied in **machine** coordinates, after tool offsets, tool length is handled
+automatically. A longer tool puts the carriage higher for the same work Z, the leader's machine
+coordinate rises, and the follower moves down by the same amount — which is exactly what the shoe
+needs.
+
+That makes the `U{-var.newOffset}` half of
+
+```gcode
+G10 L1 Z{var.newOffset} U{-var.newOffset}
+```
+
+redundant while following is engaged. It is harmless — the follower's coordinate is derived, so a U
+tool offset is simply ignored — but it is misleading to leave in, because it looks like it is doing
+something.
+
+## Limitations
+
+* Movement system 0 only.
+* One follower relationship at a time.
+* The follower must not be the leader.
+* `M604` is a provisional command number. It was free in this firmware; check it against anything else
+  you rely on before adopting it widely.

--- a/Developer-documentation/Axis following (M604).md
+++ b/Developer-documentation/Axis following (M604).md
@@ -106,6 +106,17 @@ redundant while following is engaged. It is harmless — the follower's coordina
 tool offset is simply ignored — but it is misleading to leave in, because it looks like it is doing
 something.
 
+## Object model
+
+`move.axisFollower` reports the state, so a UI does not have to parse the text of an `M604` report:
+
+```json
+{"engaged":true,"follower":"U","leader":"Z","offset":70.000,"scale":-1.000}
+```
+
+`follower` and `leader` are empty strings when nothing is configured. `engaged` is flagged `live`, so
+it appears in the frequently-updated part of the model.
+
 ## Limitations
 
 * Movement system 0 only.

--- a/Developer-documentation/Velocity jogging (M700).md
+++ b/Developer-documentation/Velocity jogging (M700).md
@@ -55,24 +55,34 @@ Measured on the emulator, timing from command injection to the step pins changin
 |---|---|---|---|
 | 5 | 50 ms | 257 ms | 100 mm/s |
 | 3 | 20 ms | 126 ms | 40 mm/s |
-| **2** | **20 ms** | **50 ms** | **40 mm/s** |
-| 2 | 15 ms | 62 ms | 30 mm/s |
-| 2 | 10 ms | 127 ms | 20 mm/s |
+| 2 | 30 ms | 90 ms | 60 mm/s |
+| 2 | 25 ms | 67 ms | 50 mm/s |
+| **2** | **20 ms** | **38.5 ms** | **40 mm/s** |
+| 2 | 15 ms | 44.6 ms | 30 mm/s |
+| 2 | 10 ms | never reaches 15 mm/s | 20 mm/s |
 
-The defaults are `D2 P20` because that is the measured optimum, not a compromise: latency stops
-following `D x P` below roughly 40ms of queued motion and then gets **worse**, because `Move` wants
-about `MoveTiming::UsualMinimumPreparedTime` (50ms, absolute minimum 25ms) queued before it will run
-moves. Shortening the chunk or the queue past that point makes jogging slower to respond, not faster.
+The defaults are `D2 P20` because that is the measured optimum, not a compromise. Above it latency
+tracks the queued chunk time `D x P`, as a FIFO should. Below roughly 40ms of queued motion it stops
+following `D x P` and gets **worse**, and shortening `P` far enough stops the axis reaching the
+commanded speed at all.
 
-Doubling the command rate (20ms to 10ms cadence) changed the result by 0.3ms, so this floor is in the
-firmware, not in how fast a host can send.
+**What that floor is not.** Three plausible explanations were measured and none of them holds:
 
-**To go below ~50ms** you have to reduce the preparation window in `MoveTiming`, which also affects
-print move preparation and CAN expansion timing. That is a machine-wide trade and has not been made
-here.
+| hypothesis | test | result |
+|---|---|---|
+| `Move` wants `MoveTiming::UsualMinimumPreparedTime` queued | halved it, 50ms to 25ms | 50.3 -> 50.2 ms: no effect |
+| lookahead grace period delays the first move | `M595 R0`, and `R0 P40` | ~2 ms |
+| the host cannot send fast enough | doubled command rate to 10ms cadence | 0.3 ms |
+
+Sizing the chunk adaptively to the requested speed - a short chunk for a slow jog, which the `2.a.P`
+ceiling says should be safe - was also implemented and measured, and is much worse: 3 to 15 mm/s went
+39.5 -> 75.4 ms and 1 to 3 mm/s went 79 -> 245 ms. It is not in the tree.
+
+So the sub-40ms floor is real and its cause is not yet identified. Going below it needs a mechanism
+this design does not have: revising a chunk that is already queued, rather than waiting it out.
 
 **To get more speed at the same latency, raise acceleration** rather than lengthening the chunk. The
-ceiling is `2.a.P`, so `M201 X4000` with `P=20` gives 160mm/s at the same 50ms.
+ceiling is `2.a.P`, so `M201 X4000` with `P=20` gives 160mm/s at the same ~38ms.
 
 ## Safety
 

--- a/Developer-documentation/Velocity jogging (M700).md
+++ b/Developer-documentation/Velocity jogging (M700).md
@@ -65,6 +65,22 @@ the underlying handoff: `JogController::Spin` can only add one chunk per pass be
 `ms.segmentsLeft` to return to zero, which makes the fill rate a ping-pong between the GCode and Move
 tasks. Letting it enqueue more per pass would allow a shallower queue and lower latency.
 
+## What has actually been measured
+
+Everything below was run under the Renode emulator (`duet3-emulation/`), driving `M700` over the
+emulated aux UART and reconstructing velocity from timestamped STEP-pin edges. These are measurements,
+not arguments.
+
+| Claim | Result |
+|---|---|
+| Chunks blend into steady motion | Confirmed **at `D5`**. At the original `D3` it did not: a 20Hz stream at 10mm/s collapsed to 2.5mm/s at chunk boundaries and lost 7% of the commanded distance. That is what raised the default. |
+| Speed ceiling is `2·a·P` | Confirmed and linear in `P`. Commanding 90mm/s gave a measured peak of 20.08, 40.23 and 81.31 mm/s at `P` = 10, 20 and 40ms, against 20, 40 and 80 predicted. |
+| Losing the command stream decelerates rather than stops dead | Confirmed. A single `M700 X10` travels 3mm and stops: the 250ms watchdog plus the chunks already queued behind it. |
+| An axis at its limit stops, others keep their speed | Confirmed. With `M208 X0:5` and `M700 X10 Y10`, X stopped at exactly 5.000mm while Y carried on to 10.000mm at a steady 10.00mm/s. |
+
+Untested on real hardware. An emulator models what it was told to model: step timing here comes from
+the TC model, and nothing checks that a real TMC5160 driver would follow the pulses.
+
 ## Safety
 
 * **Speed clamp.** Each axis is clamped to its `M203` maximum *and* to `2·a·P`. That second limit is not

--- a/Developer-documentation/Velocity jogging (M700).md
+++ b/Developer-documentation/Velocity jogging (M700).md
@@ -15,7 +15,7 @@ M700 X<speed> Y<speed> Z<speed> ... [S0] [P<ms>] [R<ms>] [D<n>]
 | `S0` | Stop jogging now. |
 | `P` | Chunk time in ms, 10..200, default 50. See *Latency* below. |
 | `R` | Watchdog timeout in ms, default 250. |
-| `D` | How many moves to keep queued, 2..8, default 3. |
+| `D` | How many moves to keep queued, 2..8, default 5. |
 | none | Report status. |
 
 **The axis letters present define the whole velocity vector.** Any axis you do not mention is set to zero.
@@ -50,8 +50,20 @@ That reuse is the whole point of the design:
 ## Latency
 
 Response to a stick movement is roughly `D × P` plus the ~50 ms that `Move` prepares ahead
-(`MoveTiming::UsualMinimumPreparedTime`) — about 150–200 ms at the defaults. Reducing `D` or `P` sharpens
-the response but lowers the speed ceiling (see below) and leaves less slack for a busy main loop.
+(`MoveTiming::UsualMinimumPreparedTime`) — about **300 ms** at the defaults.
+
+`D` defaulted to 3 originally, for ~200 ms. That does not work. Measured under the Renode emulator, a
+20 Hz `M700` stream at 10 mm/s with `D3` collapses to 2.5 mm/s at chunk boundaries and loses 7% of the
+commanded distance: the producer cannot keep the ring topped up, so the ring repeatedly holds a single
+move, and lookahead correctly plans that move to stop at its end. `D4` is clean and `D5` is the default
+for margin, since a real machine has heaters, networking and the SD card competing for the same main
+loop that tops the queue up.
+
+If 300 ms is too slow, the honest lever is not `D` — dropping it back reintroduces the stutter. Either
+shorten `P` (which also lowers the speed ceiling below) and raise `D` to keep the same buffer, or fix
+the underlying handoff: `JogController::Spin` can only add one chunk per pass because it waits for
+`ms.segmentsLeft` to return to zero, which makes the fill rate a ping-pong between the GCode and Move
+tasks. Letting it enqueue more per pass would allow a shallower queue and lower latency.
 
 ## Safety
 

--- a/Developer-documentation/Velocity jogging (M700).md
+++ b/Developer-documentation/Velocity jogging (M700).md
@@ -1,0 +1,89 @@
+# Velocity jogging — M700
+
+Normal motion commands say *where* to go. `M700` says *how fast to go, and in which direction*, per axis,
+so an analogue input such as a joystick can drive the machine directly.
+
+## Command
+
+```
+M700 X<speed> Y<speed> Z<speed> ... [S0] [P<ms>] [R<ms>] [D<n>]
+```
+
+| Parameter | Meaning |
+|---|---|
+| axis letters | Signed speed for that axis in **mm/sec** (degrees/sec for rotational axes). `G20` does *not* rescale these. |
+| `S0` | Stop jogging now. |
+| `P` | Chunk time in ms, 10..200, default 50. See *Latency* below. |
+| `R` | Watchdog timeout in ms, default 250. |
+| `D` | How many moves to keep queued, 2..8, default 3. |
+| none | Report status. |
+
+**The axis letters present define the whole velocity vector.** Any axis you do not mention is set to zero.
+A truncated or partially-parsed command therefore cannot leave an axis running.
+
+Send a fresh `M700` whenever the stick moves, and at least every `R` milliseconds while it is off centre.
+
+```gcode
+M700 X25 Y-12     ; X at +25 mm/s, Y at -12 mm/s, everything else stopped
+M700 X25          ; Y now stops, X carries on
+M700 S0           ; stop
+```
+
+## How it works
+
+Jogging synthesises a stream of short constant-velocity moves and feeds them to movement system 0 through
+exactly the same path a `G1` takes: `MovementState::raw` → `GCodes::ReadMove` → `DDARing::AddStandardMove`.
+
+That reuse is the whole point of the design:
+
+* **Lookahead blends the chunks**, so a steady stick gives steady motion, and changing the stick direction
+  produces a normal cornered junction rather than a stop-start.
+* **The last move in the ring is always planned to end at zero speed.** If the command stream dies — cable
+  pulled, host crashed, task starved — the machine decelerates to a stop under its normal acceleration
+  limits instead of stopping dead and losing steps.
+* Per-axis speed and acceleration limits, kinematics, bed compensation and tool offsets all apply
+  unchanged.
+
+`JogController::Spin()` is called from `GCodes::Spin()` and tops the queue up whenever it holds fewer than
+`D` moves.
+
+## Latency
+
+Response to a stick movement is roughly `D × P` plus the ~50 ms that `Move` prepares ahead
+(`MoveTiming::UsualMinimumPreparedTime`) — about 150–200 ms at the defaults. Reducing `D` or `P` sharpens
+the response but lowers the speed ceiling (see below) and leaves less slack for a busy main loop.
+
+## Safety
+
+* **Speed clamp.** Each axis is clamped to its `M203` maximum *and* to `2·a·P`. That second limit is not
+  arbitrary: `DDA::InitStandardMove` caps the entry speed of every move at `sqrt(2·a·d)` for that move
+  alone, so that any move can be the last one in the ring and still stop at its end. With `d = v·P` that
+  solves to `v ≤ 2·a·P`. Commanding more would not go faster, it would silently not be obeyed, so `M700`
+  clamps to it. At the defaults with a = 1000 mm/s² the ceiling is 100 mm/s (6000 mm/min); **to jog faster,
+  raise `P`** — and accept the extra latency.
+* **Watchdog.** If no `M700` arrives within `R` ms, the velocity is zeroed and the machine decelerates.
+* **Axis limits.** Every chunk is passed through `Kinematics::LimitPosition` with `initialCoords` set, so
+  the whole line is checked, not just its end point. An axis that reaches its limit simply stops; the
+  others keep their commanded speed, because the chunk still takes one chunk time to execute.
+* **Homing.** Starting a jog requires the same axes to be homed that a `G1` would, subject to `M564`.
+* **Interlocks.** Jogging refuses to start while a print is running, stops if one starts, and is cancelled
+  by anything that waits for standstill on movement system 0 (`G28`, `G30`, most `M` codes that move) and
+  by `M112`/`M999`.
+
+For an immediate halt, use `M112` — `M700 S0` decelerates.
+
+## Limitations
+
+* Movement system 0 only.
+* Mentioning linear and rotational axes in the same command works, but RepRapFirmware treats the two
+  groups' feedrates separately, so the resulting speeds are only approximately as commanded.
+* RepRapFirmware has no USB host stack: the joystick has to be read by an SBC, Pi or other host that then
+  sends `M700` over USB or the network, ideally on its own input channel.
+
+## Where the code is
+
+| | |
+|---|---|
+| `src/Movement/JogController.{h,cpp}` | all of the logic |
+| `src/GCodes/GCodes.cpp` | `Spin()` calls `jogController.Spin()`; `Reset()` and `LockMovementSystemAndWaitForStandstill()` stop it |
+| `src/GCodes/GCodes2.cpp` | `M700` dispatch |

--- a/Developer-documentation/Velocity jogging (M700).md
+++ b/Developer-documentation/Velocity jogging (M700).md
@@ -13,9 +13,9 @@ M700 X<speed> Y<speed> Z<speed> ... [S0] [P<ms>] [R<ms>] [D<n>]
 |---|---|
 | axis letters | Signed speed for that axis in **mm/sec** (degrees/sec for rotational axes). `G20` does *not* rescale these. |
 | `S0` | Stop jogging now. |
-| `P` | Chunk time in ms, 10..200, default 50. See *Latency* below. |
+| `P` | Chunk time in ms, 10..200, default 20. See *Latency* below. |
 | `R` | Watchdog timeout in ms, default 250. |
-| `D` | How many moves to keep queued, 2..8, default 5. |
+| `D` | How many moves to keep queued, 2..8, default 2. |
 | none | Report status. |
 
 **The axis letters present define the whole velocity vector.** Any axis you do not mention is set to zero.
@@ -49,37 +49,30 @@ That reuse is the whole point of the design:
 
 ## Latency
 
-Response to a stick movement is roughly `D × P` plus the ~50 ms that `Move` prepares ahead
-(`MoveTiming::UsualMinimumPreparedTime`) — about **300 ms** at the defaults.
+Measured on the emulator, timing from command injection to the step pins changing rate:
 
-`D` defaulted to 3 originally, for ~200 ms. That does not work. Measured under the Renode emulator, a
-20 Hz `M700` stream at 10 mm/s with `D3` collapses to 2.5 mm/s at chunk boundaries and loses 7% of the
-commanded distance: the producer cannot keep the ring topped up, so the ring repeatedly holds a single
-move, and lookahead correctly plans that move to stop at its end. `D4` is clean and `D5` is the default
-for margin, since a real machine has heaters, networking and the SD card competing for the same main
-loop that tops the queue up.
+| `D` | `P` | Latency | Ceiling |
+|---|---|---|---|
+| 5 | 50 ms | 257 ms | 100 mm/s |
+| 3 | 20 ms | 126 ms | 40 mm/s |
+| **2** | **20 ms** | **50 ms** | **40 mm/s** |
+| 2 | 15 ms | 62 ms | 30 mm/s |
+| 2 | 10 ms | 127 ms | 20 mm/s |
 
-If 300 ms is too slow, the honest lever is not `D` — dropping it back reintroduces the stutter. Either
-shorten `P` (which also lowers the speed ceiling below) and raise `D` to keep the same buffer, or fix
-the underlying handoff: `JogController::Spin` can only add one chunk per pass because it waits for
-`ms.segmentsLeft` to return to zero, which makes the fill rate a ping-pong between the GCode and Move
-tasks. Letting it enqueue more per pass would allow a shallower queue and lower latency.
+The defaults are `D2 P20` because that is the measured optimum, not a compromise: latency stops
+following `D x P` below roughly 40ms of queued motion and then gets **worse**, because `Move` wants
+about `MoveTiming::UsualMinimumPreparedTime` (50ms, absolute minimum 25ms) queued before it will run
+moves. Shortening the chunk or the queue past that point makes jogging slower to respond, not faster.
 
-## What has actually been measured
+Doubling the command rate (20ms to 10ms cadence) changed the result by 0.3ms, so this floor is in the
+firmware, not in how fast a host can send.
 
-Everything below was run under the Renode emulator (`duet3-emulation/`), driving `M700` over the
-emulated aux UART and reconstructing velocity from timestamped STEP-pin edges. These are measurements,
-not arguments.
+**To go below ~50ms** you have to reduce the preparation window in `MoveTiming`, which also affects
+print move preparation and CAN expansion timing. That is a machine-wide trade and has not been made
+here.
 
-| Claim | Result |
-|---|---|
-| Chunks blend into steady motion | Confirmed **at `D5`**. At the original `D3` it did not: a 20Hz stream at 10mm/s collapsed to 2.5mm/s at chunk boundaries and lost 7% of the commanded distance. That is what raised the default. |
-| Speed ceiling is `2·a·P` | Confirmed and linear in `P`. Commanding 90mm/s gave a measured peak of 20.08, 40.23 and 81.31 mm/s at `P` = 10, 20 and 40ms, against 20, 40 and 80 predicted. |
-| Losing the command stream decelerates rather than stops dead | Confirmed. A single `M700 X10` travels 3mm and stops: the 250ms watchdog plus the chunks already queued behind it. |
-| An axis at its limit stops, others keep their speed | Confirmed. With `M208 X0:5` and `M700 X10 Y10`, X stopped at exactly 5.000mm while Y carried on to 10.000mm at a steady 10.00mm/s. |
-
-Untested on real hardware. An emulator models what it was told to model: step timing here comes from
-the TC model, and nothing checks that a real TMC5160 driver would follow the pulses.
+**To get more speed at the same latency, raise acceleration** rather than lengthening the chunk. The
+ceiling is `2.a.P`, so `M201 X4000` with `P=20` gives 160mm/s at the same 50ms.
 
 ## Safety
 

--- a/src/GCodes/GCodes.cpp
+++ b/src/GCodes/GCodes.cpp
@@ -238,6 +238,8 @@ void GCodes::Reset() noexcept
 
 	nextGcodeSource = 0;
 
+	jogController.Stop();
+
 #if HAS_MASS_STORAGE || HAS_EMBEDDED_FILES
 	fileToPrint.Close();
 #endif
@@ -466,6 +468,8 @@ void GCodes::Spin() noexcept
 #endif
 
 	CheckTriggers();
+
+	jogController.Spin();							// keep the movement queue topped up if we are jogging
 
 	// The autoPause buffer has priority, so spin that one first. It may have to wait for other buffers to release locks etc.
 	(void)SpinGCodeBuffer(*AutoPauseGCode());
@@ -1853,6 +1857,11 @@ bool GCodes::LockAllMovementSystemsAndWaitForStandstill(GCodeBuffer& gb) noexcep
 // As a side-effect it updates the user coordinates from the machine coordinates.
 bool GCodes::LockMovementSystemAndWaitForStandstill(GCodeBuffer& gb, MovementSystemNumber msNumber) noexcept
 {
+	if (msNumber == 0)
+	{
+		jogController.Stop();						// jogging keeps feeding the queue, so we would never reach standstill while it is running
+	}
+
 	// Lock movement to stop another source adding moves to the queue
 	if (!LockResource(gb, MoveResourceBase + msNumber))
 	{

--- a/src/GCodes/GCodes.cpp
+++ b/src/GCodes/GCodes.cpp
@@ -5076,6 +5076,7 @@ void GCodes::SetAxisNotHomed(unsigned int axis) noexcept
 	{
 		axesHomed.ClearBit(axis);
 		axesVirtuallyHomed = axesHomed;
+		axisFollower.NotifyAxisNotHomed(axis);
 		if (axis == Z_AXIS)
 		{
 			zDatumSetByProbing = false;
@@ -5092,6 +5093,7 @@ void GCodes::SetAllAxesNotHomed() noexcept
 	{
 		axesHomed.Clear();
 		axesVirtuallyHomed = axesHomed;
+		axisFollower.Disengage();
 		zDatumSetByProbing = false;
 		Tool::CheckZHopsValid(axesHomed);
 		reprap.MoveUpdated();

--- a/src/GCodes/GCodes.cpp
+++ b/src/GCodes/GCodes.cpp
@@ -4963,12 +4963,23 @@ void GCodes::ToolOffsetTransform(const MovementState& ms, const float coordsIn[M
 			}
 		}
 	}
+
+	// A following axis is derived last, from the machine coordinates, so that it tracks where the tool
+	// actually ends up rather than where it was asked to go. Tool length offsets are already applied
+	// here, which is what a G-code implementation has to compensate for by hand.
+	// This is the one point every move passes through - straight moves, arc segments and jog chunks -
+	// so deriving it here is what makes the follower part of the same move rather than a reaction to it.
+	axisFollower.Apply(coordsOut);
 }
 
 // Convert user coordinates to head reference point coordinates
 void GCodes::ToolOffsetTransform(MovementState& ms, AxesBitmap explicitAxes) const noexcept
 {
 	ToolOffsetTransform(ms, ms.currentUserPosition, ms.raw.coords, explicitAxes);
+
+	// Nothing commands the follower, so its user coordinate would otherwise never move and M114 and the
+	// object model would report a stale position while the machine coordinate tracked the leader.
+	axisFollower.SyncUserPosition(ms.currentUserPosition, ms.raw.coords, axisScaleFactors);
 }
 
 // Convert head reference point coordinates to user coordinates

--- a/src/GCodes/GCodes.h
+++ b/src/GCodes/GCodes.h
@@ -43,6 +43,7 @@ Licence: GPL
 #include <Movement/HomingMode.h>
 #include <Movement/MovementError.h>
 #include <Movement/JogController.h>
+#include <Movement/AxisFollower.h>
 
 #if HAS_MASS_STORAGE || HAS_EMBEDDED_FILES
 # include <Storage/CRC32.h>
@@ -274,6 +275,9 @@ public:
 	const MovementState& GetConstMovementState(const GCodeBuffer& gb) const noexcept;			// Get a reference to the movement state associated with the specified GCode buffer (there is a private non-const version)
 
 	JogController& GetJogController() noexcept { return jogController; }
+	AxisFollower& GetAxisFollower() noexcept { return axisFollower; }
+	MovementState& GetMovementStateForFollower() noexcept { return moveStates[0]; }	// the follower only applies to movement system 0
+	const AxisFollower& GetAxisFollowerForJog() const noexcept { return axisFollower; }
 
 	void RecordEndstopTriggered(size_t axis, HomingMode hmode) noexcept;
 
@@ -677,6 +681,7 @@ private:
 	MovementState moveStates[NumMovementSystems];	// Move details
 
 	JogController jogController;				// Velocity-mode movement, e.g. from a joystick
+	AxisFollower axisFollower;					// One axis tracking another, e.g. a Z-independent dust shoe
 
 	size_t numTotalAxes;						// How many axes we have
 	size_t numVisibleAxes;						// How many axes are visible

--- a/src/GCodes/GCodes.h
+++ b/src/GCodes/GCodes.h
@@ -42,6 +42,7 @@ Licence: GPL
 #include <Movement/BedProbing/Grid.h>
 #include <Movement/HomingMode.h>
 #include <Movement/MovementError.h>
+#include <Movement/JogController.h>
 
 #if HAS_MASS_STORAGE || HAS_EMBEDDED_FILES
 # include <Storage/CRC32.h>
@@ -98,6 +99,8 @@ class SbcInterface;
 
 class GCodes
 {
+	friend class JogController;						// it builds moves for movement system 0 using the same private machinery that G1 does
+
 public:
 	explicit GCodes(Platform& p) noexcept;
 	void Spin() noexcept;														// Called in a tight loop to make this class work
@@ -269,6 +272,8 @@ public:
 	const MovementState& GetPrimaryMovementState() const noexcept { return moveStates[0]; }		// Temporary support for object model and status report values that only handle a single movement system
 	const MovementState& GetCurrentMovementState(const ObjectExplorationContext& context) const noexcept;
 	const MovementState& GetConstMovementState(const GCodeBuffer& gb) const noexcept;			// Get a reference to the movement state associated with the specified GCode buffer (there is a private non-const version)
+
+	JogController& GetJogController() noexcept { return jogController; }
 
 	void RecordEndstopTriggered(size_t axis, HomingMode hmode) noexcept;
 
@@ -670,6 +675,8 @@ private:
 
 	// The following contain the details of moves that the Move module fetches
 	MovementState moveStates[NumMovementSystems];	// Move details
+
+	JogController jogController;				// Velocity-mode movement, e.g. from a joystick
 
 	size_t numTotalAxes;						// How many axes we have
 	size_t numVisibleAxes;						// How many axes are visible

--- a/src/GCodes/GCodes2.cpp
+++ b/src/GCodes/GCodes2.cpp
@@ -4371,6 +4371,10 @@ bool GCodes::HandleMcode(GCodeBuffer& gb, const StringRef& reply) THROWS(GCodeEx
 				result = jogController.ProcessM700(gb, reply);
 				break;
 
+			case 604: // Configure one axis to follow another
+				result = axisFollower.Configure(gb, reply);
+				break;
+
 			case 701: // Load filament
 				result = LoadFilament(gb, reply);
 				break;

--- a/src/GCodes/GCodes2.cpp
+++ b/src/GCodes/GCodes2.cpp
@@ -4367,6 +4367,10 @@ bool GCodes::HandleMcode(GCodeBuffer& gb, const StringRef& reply) THROWS(GCodeEx
 				result = FindCenterOfCavity(gb, reply);
 				break;
 
+			case 700: // Set jog velocities
+				result = jogController.ProcessM700(gb, reply);
+				break;
+
 			case 701: // Load filament
 				result = LoadFilament(gb, reply);
 				break;

--- a/src/Movement/AxisFollower.cpp
+++ b/src/Movement/AxisFollower.cpp
@@ -1,0 +1,157 @@
+/*
+ * AxisFollower.cpp
+ *
+ *  See AxisFollower.h for what this is for.
+ */
+
+#include "AxisFollower.h"
+
+#include <GCodes/GCodes.h>
+#include <GCodes/GCodeBuffer/GCodeBuffer.h>
+#include <Movement/Move.h>
+#include <Platform/RepRap.h>
+
+AxisFollower::AxisFollower() noexcept
+	: followerAxis(-1), leaderAxis(-1), scale(-1.0), offset(0.0), engaged(false)
+{
+}
+
+void AxisFollower::Apply(float coords[MaxAxes]) const noexcept
+{
+	if (!engaged || followerAxis < 0 || leaderAxis < 0)
+	{
+		return;
+	}
+
+	const Move& move = reprap.GetMove();
+	const float wanted = (scale * coords[leaderAxis]) + offset;
+
+	// Clamped here rather than left to Kinematics::LimitPosition, which only limits axes the command
+	// actually mentioned - and the whole point is that nothing mentions the follower. Clamping is also
+	// the useful behaviour rather than an error case: a dust shoe tracks the tool down until it reaches
+	// its lower limit and then stays resting there while Z carries on into the work.
+	coords[followerAxis] = constrain<float>(wanted,
+											move.AxisMinimum((size_t)followerAxis),
+											move.AxisMaximum((size_t)followerAxis));
+}
+
+void AxisFollower::SyncUserPosition(float userCoords[MaxAxes], const float machineCoords[MaxAxes], const float scaleFactors[MaxAxes]) const noexcept
+{
+	if (engaged && followerAxis >= 0)
+	{
+		const float sf = scaleFactors[followerAxis];
+		userCoords[followerAxis] = (sf != 0.0) ? machineCoords[followerAxis] / sf : machineCoords[followerAxis];
+	}
+}
+
+// M604: configure one axis to follow another
+GCodeResult AxisFollower::Configure(GCodeBuffer& gb, const StringRef& reply) THROWS(GCodeException)
+{
+	GCodes& gcodes = reprap.GetGCodes();
+	const char *_ecv_array const axisLetters = gcodes.GetAxisLetters();
+	const size_t numVisibleAxes = gcodes.GetVisibleAxes();
+
+	bool seen = false;
+
+	if (gb.Seen('A'))
+	{
+		String<StringLength20> letter;
+		gb.GetQuotedString(letter.GetRef());
+		const char *_ecv_array const found = strchr(axisLetters, toupper(letter.c_str()[0]));
+		if (found == nullptr || (size_t)(found - axisLetters) >= numVisibleAxes)
+		{
+			reply.printf("Unknown axis '%s'", letter.c_str());
+			return GCodeResult::error;
+		}
+		followerAxis = found - axisLetters;
+		seen = true;
+	}
+
+	if (gb.Seen('B'))
+	{
+		String<StringLength20> letter;
+		gb.GetQuotedString(letter.GetRef());
+		const char *_ecv_array const found = strchr(axisLetters, toupper(letter.c_str()[0]));
+		if (found == nullptr || (size_t)(found - axisLetters) >= numVisibleAxes)
+		{
+			reply.printf("Unknown axis '%s'", letter.c_str());
+			return GCodeResult::error;
+		}
+		leaderAxis = found - axisLetters;
+		seen = true;
+	}
+
+	gb.TryGetFValue('S', scale, seen);
+	gb.TryGetFValue('O', offset, seen);
+
+	if (gb.Seen('E'))
+	{
+		const bool wanted = gb.GetUIValue() != 0;
+		if (wanted && (followerAxis < 0 || leaderAxis < 0))
+		{
+			reply.copy("Configure the follower and leader axes before engaging");
+			return GCodeResult::error;
+		}
+		if (wanted && followerAxis == leaderAxis)
+		{
+			reply.copy("An axis cannot follow itself");
+			return GCodeResult::error;
+		}
+		if (wanted && !gcodes.IsAxisHomed((unsigned int)followerAxis))
+		{
+			reply.copy("Cannot engage: the follower axis is not homed");
+			return GCodeResult::error;
+		}
+
+		// Capture the relationship at the moment of engaging unless an explicit offset was given. This
+		// is what the G-code implementation used dustShoePrevZ for: engaging means "hold the current
+		// separation from here on", not "jump to some absolute relationship".
+		if (wanted && !gb.Seen('O'))
+		{
+			MovementState& ms = gcodes.GetMovementStateForFollower();
+			const float leaderNow = ms.LiveMachineCoordinate((unsigned int)leaderAxis);
+			const float followerNow = ms.LiveMachineCoordinate((unsigned int)followerAxis);
+			offset = followerNow - (scale * leaderNow);
+		}
+
+		engaged = wanted;
+		seen = true;
+#if SUPPORT_ASYNC_MOVES
+		if (engaged)
+		{
+			// The follower has to be owned by the movement system or its motion is silently dropped:
+			// the coordinate updates and M114 reports the new machine position, but no steps come out,
+			// because nothing ever mentioned the axis in a command.
+			MovementState& owner = gcodes.GetMovementStateForFollower();
+			if (owner.AllocateAxes(AxesBitmap::MakeFromBits((unsigned int)followerAxis), ParameterLettersBitmap()).IsNonEmpty())
+			{
+				engaged = false;
+				reply.copy("Cannot engage: the follower axis is in use by another movement system");
+				return GCodeResult::error;
+			}
+		}
+#endif
+	}
+
+	if (!seen)
+	{
+		Report(reply);
+	}
+	return GCodeResult::ok;
+}
+
+void AxisFollower::Report(const StringRef& reply) const noexcept
+{
+	if (followerAxis < 0 || leaderAxis < 0)
+	{
+		reply.copy("No axis following configured");
+		return;
+	}
+	const char *_ecv_array const axisLetters = reprap.GetGCodes().GetAxisLetters();
+	reply.printf("%c follows %c as %.3f * %c %c %.3f, %s",
+					axisLetters[followerAxis], axisLetters[leaderAxis], (double)scale,
+					axisLetters[leaderAxis], (offset < 0.0) ? '-' : '+', (double)fabsf(offset),
+					(engaged) ? "engaged" : "disengaged");
+}
+
+// End

--- a/src/Movement/AxisFollower.cpp
+++ b/src/Movement/AxisFollower.cpp
@@ -10,6 +10,40 @@
 #include <GCodes/GCodeBuffer/GCodeBuffer.h>
 #include <Movement/Move.h>
 #include <Platform/RepRap.h>
+#include <ObjectModel/ObjectModel.h>
+
+// Object model. AxisControl and DWC would otherwise have to parse the text of an M604 report to know
+// whether following is engaged, which is not something a UI should have to do.
+
+// Macro to build a standard lambda function that includes the necessary type conversions
+#define OBJECT_MODEL_FUNC(...)		OBJECT_MODEL_FUNC_BODY(AxisFollower, __VA_ARGS__)
+
+constexpr ObjectModelTableEntry AxisFollower::objectModelTable[] =
+{
+	// Within each group, these entries must be in alphabetical order
+	// 0. AxisFollower members
+	{ "engaged",	OBJECT_MODEL_FUNC(self->engaged),										ObjectModelEntryFlags::live },
+	{ "follower",	OBJECT_MODEL_FUNC(self->GetAxisLetterOrNull(self->followerAxis)),		ObjectModelEntryFlags::none },
+	{ "leader",		OBJECT_MODEL_FUNC(self->GetAxisLetterOrNull(self->leaderAxis)),			ObjectModelEntryFlags::none },
+	{ "offset",		OBJECT_MODEL_FUNC(self->offset, 3),										ObjectModelEntryFlags::none },
+	{ "scale",		OBJECT_MODEL_FUNC(self->scale, 3),										ObjectModelEntryFlags::none },
+};
+
+constexpr uint8_t AxisFollower::objectModelTableDescriptor[] = { 1, 5 };
+
+DEFINE_GET_OBJECT_MODEL_TABLE(AxisFollower)
+
+// Returns null when unconfigured, so the field reads as null rather than as a bogus axis letter.
+const char *_ecv_array AxisFollower::GetAxisLetterOrNull(int32_t axis) const noexcept
+{
+	if (axis < 0)
+	{
+		return nullptr;
+	}
+	static char letter[2] = { 0, 0 };
+	letter[0] = reprap.GetGCodes().GetAxisLetters()[axis];
+	return letter;
+}
 
 AxisFollower::AxisFollower() noexcept
 	: followerAxis(-1), leaderAxis(-1), scale(-1.0), offset(0.0), engaged(false)

--- a/src/Movement/AxisFollower.cpp
+++ b/src/Movement/AxisFollower.cpp
@@ -10,6 +10,7 @@
 #include <GCodes/GCodeBuffer/GCodeBuffer.h>
 #include <Movement/Move.h>
 #include <Platform/RepRap.h>
+#include <Platform/Platform.h>
 #include <ObjectModel/ObjectModel.h>
 
 // Object model. AxisControl and DWC would otherwise have to parse the text of an M604 report to know
@@ -48,6 +49,20 @@ const char *_ecv_array AxisFollower::GetAxisLetterOrNull(int32_t axis) const noe
 AxisFollower::AxisFollower() noexcept
 	: followerAxis(-1), leaderAxis(-1), scale(-1.0), offset(0.0), engaged(false)
 {
+}
+
+// Following is a relationship between two known positions, so losing the position of either end ends it.
+// This matters most for homing: H1/H2 moves write ms.raw.coords directly and never pass through
+// ToolOffsetTransform, so the follower cannot track them. Left engaged, the machine would come out of
+// homing still claiming a relationship that the homing moves had silently broken. Disengaging says so
+// instead; re-engaging afterwards recaptures the offset, which is the intended workflow anyway.
+void AxisFollower::NotifyAxisNotHomed(unsigned int axis) noexcept
+{
+	if (engaged && ((int32_t)axis == followerAxis || (int32_t)axis == leaderAxis))
+	{
+		engaged = false;
+		reprap.GetPlatform().Message(WarningMessage, "Axis following disengaged because an axis it uses is no longer homed\n");
+	}
 }
 
 void AxisFollower::Apply(float coords[MaxAxes]) const noexcept

--- a/src/Movement/AxisFollower.h
+++ b/src/Movement/AxisFollower.h
@@ -14,8 +14,9 @@
 #define SRC_MOVEMENT_AXISFOLLOWER_H_
 
 #include <RepRapFirmware.h>
+#include <ObjectModel/ObjectModel.h>
 
-class AxisFollower
+class AxisFollower INHERIT_OBJECT_MODEL
 {
 public:
 	AxisFollower() noexcept;
@@ -34,8 +35,12 @@ public:
 	int32_t GetFollowerAxis() const noexcept { return followerAxis; }
 	void Disengage() noexcept { engaged = false; }
 
+protected:
+	DECLARE_OBJECT_MODEL
+
 private:
 	void Report(const StringRef& reply) const noexcept;
+	const char *_ecv_array GetAxisLetterOrNull(int32_t axis) const noexcept;
 
 	int32_t followerAxis;					// -1 when unconfigured
 	int32_t leaderAxis;

--- a/src/Movement/AxisFollower.h
+++ b/src/Movement/AxisFollower.h
@@ -34,6 +34,7 @@ public:
 	bool IsEngaged() const noexcept { return engaged; }
 	int32_t GetFollowerAxis() const noexcept { return followerAxis; }
 	void Disengage() noexcept { engaged = false; }
+	void NotifyAxisNotHomed(unsigned int axis) noexcept;
 
 protected:
 	DECLARE_OBJECT_MODEL

--- a/src/Movement/AxisFollower.h
+++ b/src/Movement/AxisFollower.h
@@ -1,0 +1,47 @@
+/*
+ * AxisFollower.h
+ *
+ * Makes one axis track another as part of the same coordinated move, rather than reacting to it.
+ *
+ * The motivating case is a Z-independent dust shoe on a U axis. Doing that in G-code needs a trigger
+ * that watches Z and then issues a U move, so the shoe can only start moving after Z already has, and
+ * the correcting move queues behind whatever motion is already planned. Deriving U at the point a
+ * move's target is computed instead makes the two axes part of one move: they start, accelerate and
+ * stop together because the planner never sees them as separate.
+ */
+
+#ifndef SRC_MOVEMENT_AXISFOLLOWER_H_
+#define SRC_MOVEMENT_AXISFOLLOWER_H_
+
+#include <RepRapFirmware.h>
+
+class AxisFollower
+{
+public:
+	AxisFollower() noexcept;
+
+	GCodeResult Configure(GCodeBuffer& gb, const StringRef& reply) THROWS(GCodeException);
+
+	// Derive the follower's machine coordinate from the leader's. Called for every move, so it must be
+	// cheap and must not depend on anything that changes between segments of the same move.
+	void Apply(float coords[MaxAxes]) const noexcept;
+
+	// Bring the follower's user coordinate back in step with the machine coordinate we derived, so that
+	// reporting matches reality.
+	void SyncUserPosition(float userCoords[MaxAxes], const float machineCoords[MaxAxes], const float scaleFactors[MaxAxes]) const noexcept;
+
+	bool IsEngaged() const noexcept { return engaged; }
+	int32_t GetFollowerAxis() const noexcept { return followerAxis; }
+	void Disengage() noexcept { engaged = false; }
+
+private:
+	void Report(const StringRef& reply) const noexcept;
+
+	int32_t followerAxis;					// -1 when unconfigured
+	int32_t leaderAxis;
+	float scale;							// defaults to -1: a follower carried on the leader must move the opposite way to stay put
+	float offset;							// follower = scale * leader + offset, then clamped to its axis limits
+	bool engaged;
+};
+
+#endif /* SRC_MOVEMENT_AXISFOLLOWER_H_ */

--- a/src/Movement/JogController.cpp
+++ b/src/Movement/JogController.cpp
@@ -9,6 +9,7 @@
 #include <GCodes/GCodes.h>
 #include <GCodes/GCodeBuffer/GCodeBuffer.h>
 #include <Movement/Move.h>
+#include <Movement/AxisFollower.h>
 #include <Platform/RepRap.h>
 
 // Below this the chunk is not worth queueing; it is well under one microstep on any sane machine.
@@ -189,8 +190,17 @@ GCodeResult JogController::ProcessM700(GCodeBuffer& gb, const StringRef& reply) 
 	}
 
 #if SUPPORT_ASYNC_MOVES
-	if ((newJogAxes & ~jogAxes).IsNonEmpty()					// an axis we are not already moving has been added, so it may not be ours yet
-		&& gcodes.moveStates[0].AllocateAxes(newJogAxes, ParameterLettersBitmap()).IsNonEmpty())
+	// Include any following axis in the allocation. AllocateAxes sets the owned set rather than adding
+	// to it, so jogging would otherwise drop ownership of a follower and its motion would be silently
+	// discarded - the coordinate still updates, but no steps come out.
+	AxesBitmap axesToOwn = newJogAxes;
+	const AxisFollower& follower = gcodes.GetAxisFollowerForJog();
+	if (follower.IsEngaged() && follower.GetFollowerAxis() >= 0)
+	{
+		axesToOwn.SetBit((unsigned int)follower.GetFollowerAxis());
+	}
+	if ((axesToOwn & ~jogAxes).IsNonEmpty()						// an axis we are not already moving has been added, so it may not be ours yet
+		&& gcodes.moveStates[0].AllocateAxes(axesToOwn, ParameterLettersBitmap()).IsNonEmpty())
 	{
 		reply.copy("Cannot jog: axes are in use by another movement system");
 		return GCodeResult::error;

--- a/src/Movement/JogController.cpp
+++ b/src/Movement/JogController.cpp
@@ -205,8 +205,14 @@ void JogController::Spin() noexcept
 		return;
 	}
 
-	// Something else has taken over movement, so get out of the way.
-	if (gcodes.IsReallyPrintingOrResuming())
+	// Something else has taken over movement, so get out of the way. A macro or a tool change moves axes
+	// on its own account, and jogging underneath it would fight it for the same movement system.
+	// DoingFileMacro deliberately excludes daemon.g (GCodes.cpp:374), so a daemon running on its usual
+	// cycle does not chop the jog stream up.
+	// Deliberately NOT included: WaitingForAcknowledgement. "Jog to the workpiece corner, then press OK"
+	// is a standard CNC setup pattern, and the machine is stationary with the operator at the controls,
+	// so blocking it would remove a genuinely useful workflow for no safety gain.
+	if (gcodes.IsReallyPrintingOrResuming() || gcodes.DoingFileMacro() || gcodes.IsDoingToolChange())
 	{
 		Stop();
 		return;

--- a/src/Movement/JogController.cpp
+++ b/src/Movement/JogController.cpp
@@ -44,6 +44,13 @@ void JogController::ClampSpeeds() noexcept
 	{
 		const float limit = MaxSpeedForAxis(axis);
 		requestedSpeeds[axis] = constrain<float>(requestedSpeeds[axis], -limit, limit);
+		// A speed below one chunk's minimum distance cannot be expressed at all, so treat it as zero rather
+		// than as a jog that generates nothing. Otherwise the axis counts as jogging, keeps the machine out
+		// of idle, and produces a chunk per pass that is only thrown away.
+		if (fabsf(requestedSpeeds[axis]) * (float)chunkClocks < MinChunkDistance)
+		{
+			requestedSpeeds[axis] = 0.0;
+		}
 		if (requestedSpeeds[axis] != 0.0)
 		{
 			jogAxes.SetBit(axis);
@@ -273,7 +280,13 @@ bool JogController::GenerateChunk(MovementState& ms) noexcept
 
 	if (distanceSquared < fsquare(MinChunkDistance))
 	{
-		return false;														// every jogged axis is up against its limit
+		// Nothing worth moving. The target has to be put back, not just abandoned: currentUserPosition was
+		// already advanced above, and SetMoveBufferDefaults seeds initialCoords from raw.coords, so a
+		// rejected chunk would otherwise become the next chunk's baseline and the reported position would
+		// climb at the commanded speed while the machine stood still, with nothing ever resyncing it.
+		memcpyf(ms.raw.coords, ms.initialCoords, numVisibleAxes);
+		gcodes.ToolOffsetInverseTransform(ms, ms.raw.coords, ms.currentUserPosition);
+		return false;
 	}
 
 	ms.raw.isCoordinated = true;

--- a/src/Movement/JogController.cpp
+++ b/src/Movement/JogController.cpp
@@ -1,0 +1,289 @@
+/*
+ * JogController.cpp
+ *
+ *  See JogController.h for what this does.
+ */
+
+#include "JogController.h"
+
+#include <GCodes/GCodes.h>
+#include <GCodes/GCodeBuffer/GCodeBuffer.h>
+#include <Movement/Move.h>
+#include <Platform/RepRap.h>
+
+// Below this the chunk is not worth queueing; it is well under one microstep on any sane machine.
+constexpr float MinChunkDistance = 0.001;
+
+JogController::JogController() noexcept
+	: jogAxes(), chunkMillis(DefaultChunkMillis), chunkClocks((DefaultChunkMillis * StepClockRate)/1000),
+	  timeoutMillis(DefaultTimeoutMillis), whenLastCommanded(0), maxQueuedMoves(DefaultMaxQueuedMoves), active(false)
+{
+	for (float& s : requestedSpeeds)
+	{
+		s = 0.0;
+	}
+}
+
+// The highest speed we are prepared to run this axis at.
+// Besides the configured maximum there is a limit inherent in feeding the queue a chunk at a time. DDA::InitStandardMove
+// caps the entry speed of every move at sqrt(2.a.d) for that move alone, so that the move can always be the last one in
+// the ring and still stop at its end. With d = v.chunkTime that solves to v <= 2.a.chunkTime. Commanding more than this
+// would not go any faster, it would just quietly not be obeyed - so clamp to it and let the caller see the real ceiling.
+// Jogging faster means longer chunks, which means more latency; that trade-off is the P parameter of M700.
+float JogController::MaxSpeedForAxis(size_t axis) const noexcept
+{
+	const Move& move = reprap.GetMove();
+	return min<float>(move.MaxFeedrate(axis), 2.0 * move.NormalAcceleration(axis) * (float)chunkClocks);
+}
+
+void JogController::ClampSpeeds() noexcept
+{
+	const size_t numVisibleAxes = reprap.GetGCodes().GetVisibleAxes();
+	jogAxes.Clear();
+	for (size_t axis = 0; axis < numVisibleAxes; ++axis)
+	{
+		const float limit = MaxSpeedForAxis(axis);
+		requestedSpeeds[axis] = constrain<float>(requestedSpeeds[axis], -limit, limit);
+		if (requestedSpeeds[axis] != 0.0)
+		{
+			jogAxes.SetBit(axis);
+		}
+	}
+	for (size_t axis = numVisibleAxes; axis < MaxAxes; ++axis)
+	{
+		requestedSpeeds[axis] = 0.0;
+	}
+}
+
+void JogController::Stop() noexcept
+{
+	for (float& s : requestedSpeeds)
+	{
+		s = 0.0;
+	}
+	jogAxes.Clear();
+	active = false;
+}
+
+void JogController::ReportStatus(const StringRef& reply) const noexcept
+{
+	const GCodes& gcodes = reprap.GetGCodes();
+	const char *_ecv_array const axisLetters = gcodes.GetAxisLetters();
+	reply.printf("Jogging %s, chunk %" PRIu32 "ms, timeout %" PRIu32 "ms, queue %u",
+					(active) ? "active" : "inactive", chunkMillis, timeoutMillis, maxQueuedMoves);
+	if (active)
+	{
+		reply.cat(", speeds");
+		for (size_t axis = 0; axis < gcodes.GetVisibleAxes(); ++axis)
+		{
+			if (jogAxes.IsBitSet(axis))
+			{
+				reply.catf(" %c%.1f", axisLetters[axis], (double)InverseConvertSpeedToMmPerSec(requestedSpeeds[axis]));
+			}
+		}
+	}
+}
+
+// M700: set the jog velocity of each axis, in mm (or degrees) per second.
+// The axis letters that are present define the whole velocity vector: any axis not mentioned is set to zero, so that a
+// truncated or lost command can never leave an axis running.
+GCodeResult JogController::ProcessM700(GCodeBuffer& gb, const StringRef& reply) THROWS(GCodeException)
+{
+	GCodes& gcodes = reprap.GetGCodes();
+	const char *_ecv_array const axisLetters = gcodes.GetAxisLetters();
+	const size_t numVisibleAxes = gcodes.GetVisibleAxes();
+
+	// Tuning parameters. These take effect on the next chunk.
+	bool seenParam = false;
+	gb.TryGetLimitedUIValue('P', chunkMillis, seenParam, MinChunkMillis, MaxChunkMillis + 1);
+	gb.TryGetLimitedUIValue('R', timeoutMillis, seenParam, 1, MaxTimeoutMillis + 1);
+	uint32_t queueDepth = maxQueuedMoves;
+	gb.TryGetLimitedUIValue('D', queueDepth, seenParam, MinMaxQueuedMoves, MaxMaxQueuedMoves + 1);
+	chunkClocks = (chunkMillis * StepClockRate)/1000;
+	maxQueuedMoves = queueDepth;
+
+	// S0 is an explicit stop.
+	if (gb.Seen('S') && gb.GetUIValue() == 0)
+	{
+		Stop();
+		return GCodeResult::ok;
+	}
+
+	float newSpeeds[MaxAxes] = { 0.0 };
+	bool seenAxis = false;
+	for (size_t axis = 0; axis < numVisibleAxes; ++axis)
+	{
+		if (gb.Seen(axisLetters[axis]))
+		{
+			// Speeds are always in mm (or degrees) per second. G20 deliberately does not rescale them: the sender of a
+			// velocity command should not have its meaning changed by modal state it may know nothing about.
+			newSpeeds[axis] = ConvertSpeedFromMmPerSec(gb.GetFValue());
+			seenAxis = true;
+		}
+		else
+		{
+			newSpeeds[axis] = 0.0;
+		}
+	}
+
+	if (!seenAxis)
+	{
+		if (!seenParam)
+		{
+			ReportStatus(reply);
+		}
+		return GCodeResult::ok;
+	}
+
+	AxesBitmap newJogAxes;
+	for (size_t axis = 0; axis < numVisibleAxes; ++axis)
+	{
+		if (newSpeeds[axis] != 0.0)
+		{
+			newJogAxes.SetBit(axis);
+		}
+	}
+
+	if (newJogAxes.IsNonEmpty() && gcodes.CheckEnoughAxesHomed(newJogAxes))
+	{
+		reply.copy("Insufficient axes homed");
+		return GCodeResult::error;
+	}
+
+	if (!active && newJogAxes.IsNonEmpty())
+	{
+		// Starting up. We take over the axis positions of movement system 0, so it must be at a standstill and not printing.
+		if (gcodes.IsReallyPrintingOrResuming())
+		{
+			reply.copy("Cannot jog while a print is running");
+			return GCodeResult::error;
+		}
+		if (!gcodes.LockMovementSystemAndWaitForStandstill(gb, 0))
+		{
+			return GCodeResult::notFinished;
+		}
+	}
+
+#if SUPPORT_ASYNC_MOVES
+	if ((newJogAxes & ~jogAxes).IsNonEmpty()					// an axis we are not already moving has been added, so it may not be ours yet
+		&& gcodes.moveStates[0].AllocateAxes(newJogAxes, ParameterLettersBitmap()).IsNonEmpty())
+	{
+		reply.copy("Cannot jog: axes are in use by another movement system");
+		return GCodeResult::error;
+	}
+#endif
+
+	memcpyf(requestedSpeeds, newSpeeds, numVisibleAxes);
+	ClampSpeeds();
+	whenLastCommanded = millis();
+	active = jogAxes.IsNonEmpty();
+	return GCodeResult::ok;
+}
+
+// Top the movement queue up. Called regularly from GCodes::Spin.
+void JogController::Spin() noexcept
+{
+	if (!active)
+	{
+		return;
+	}
+
+	GCodes& gcodes = reprap.GetGCodes();
+	Move& move = reprap.GetMove();
+
+	// Watchdog: an input that stops sending must not leave the machine moving.
+	if (millis() - whenLastCommanded > timeoutMillis)
+	{
+		Stop();
+		return;
+	}
+
+	// Something else has taken over movement, so get out of the way.
+	if (gcodes.IsReallyPrintingOrResuming())
+	{
+		Stop();
+		return;
+	}
+
+	MovementState& ms = gcodes.moveStates[0];
+	if (ms.segmentsLeft != 0)
+	{
+		return;																// the previous chunk has not been picked up yet
+	}
+	if (move.GetScheduledMoves() - move.GetCompletedMoves() >= maxQueuedMoves)
+	{
+		return;																// far enough ahead already; queueing more would only add latency
+	}
+
+	(void)GenerateChunk(ms);
+}
+
+// Build one constant-velocity chunk and hand it to the Move subsystem. Return true if we queued anything.
+bool JogController::GenerateChunk(MovementState& ms) noexcept
+{
+	GCodes& gcodes = reprap.GetGCodes();
+	Move& move = reprap.GetMove();
+	const size_t numVisibleAxes = gcodes.GetVisibleAxes();
+
+	gcodes.SetMoveBufferDefaults(ms);										// this also copies the previous target into ms.initialCoords
+
+	for (size_t axis = 0; axis < numVisibleAxes; ++axis)
+	{
+		if (requestedSpeeds[axis] != 0.0)
+		{
+			ms.currentUserPosition[axis] += requestedSpeeds[axis] * (float)chunkClocks;
+		}
+	}
+
+	ms.raw.movementTool = ms.currentTool;
+	gcodes.ToolOffsetTransform(ms, jogAxes);
+
+	// Limit the whole line rather than just its end point, so that kinematics with a non-rectangular envelope stay inside it.
+	const LimitPositionResult lp = move.GetKinematics().LimitPosition(ms.raw.coords, ms.initialCoords, numVisibleAxes,
+																		gcodes.axesVirtuallyHomed & jogAxes, true, gcodes.limitAxes);
+	if (lp == LimitPositionResult::intermediateUnreachable || lp == LimitPositionResult::adjustedAndIntermediateUnreachable)
+	{
+		Stop();
+		return false;
+	}
+	if (lp == LimitPositionResult::adjusted)
+	{
+		gcodes.ToolOffsetInverseTransform(ms, ms.raw.coords, ms.currentUserPosition);	// the target was clipped, so put the user position back in step with it
+	}
+
+	// Axes that have run into their limit contribute nothing to the distance, which is exactly what keeps the remaining
+	// axes at their commanded speed: every axis still covers its own delta in one chunk time.
+	float distanceSquared = 0.0;
+	for (size_t axis = 0; axis < numVisibleAxes; ++axis)
+	{
+		const float d = ms.raw.coords[axis] - ms.initialCoords[axis];
+		if (d != 0.0)
+		{
+			distanceSquared += fsquare(d);
+			if (move.IsAxisRotational(axis))
+			{
+				ms.raw.rotationalAxesMentioned = true;
+			}
+			else
+			{
+				ms.raw.linearAxesMentioned = true;
+			}
+		}
+	}
+
+	if (distanceSquared < fsquare(MinChunkDistance))
+	{
+		return false;														// every jogged axis is up against its limit
+	}
+
+	ms.raw.isCoordinated = true;
+	ms.raw.canPauseAfter = true;
+	ms.raw.feedRate = fastSqrtf(distanceSquared)/(float)chunkClocks;
+	ms.raw.originalFeedRate = (float16_t)(InverseConvertSpeedToMmPerSec(ms.raw.feedRate) * MinutesToSeconds);	// this field is in mm/min
+	ms.raw.moveStartVirtualExtruderPosition = ms.latestVirtualExtruderPosition;
+
+	gcodes.NewSegmentableMoveAvailable(ms);
+	return true;
+}
+
+// End

--- a/src/Movement/JogController.cpp
+++ b/src/Movement/JogController.cpp
@@ -24,25 +24,31 @@ JogController::JogController() noexcept
 	}
 }
 
-// The highest speed we are prepared to run this axis at.
-// Besides the configured maximum there is a limit inherent in feeding the queue a chunk at a time. DDA::InitStandardMove
-// caps the entry speed of every move at sqrt(2.a.d) for that move alone, so that the move can always be the last one in
-// the ring and still stop at its end. With d = v.chunkTime that solves to v <= 2.a.chunkTime. Commanding more than this
-// would not go any faster, it would just quietly not be obeyed - so clamp to it and let the caller see the real ceiling.
-// Jogging faster means longer chunks, which means more latency; that trade-off is the P parameter of M700.
+// The highest speed we are prepared to run this axis at: its configured maximum, and nothing else.
+//
+// This used to also clamp to 2.a.P. That came from every chunk having to be stoppable within itself,
+// because DDA::InitStandardMove sets endSpeed = 0 (DDA.cpp:624) until a following move exists, and a
+// singly-generated chunk never had one. The machine never needed to stop within one chunk; it needs to
+// be able to decelerate from its current speed, which takes v/a however the motion was commanded.
+// Keeping enough chunks queued that each has a successor lets lookahead blend them, which is what an
+// ordinary G-code stream already relies on.
 float JogController::MaxSpeedForAxis(size_t axis) const noexcept
 {
-	const Move& move = reprap.GetMove();
-	return min<float>(move.MaxFeedrate(axis), 2.0 * move.NormalAcceleration(axis) * (float)chunkClocks);
+	return reprap.GetMove().MaxFeedrate(axis);
 }
 
 void JogController::ClampSpeeds() noexcept
 {
 	const size_t numVisibleAxes = reprap.GetGCodes().GetVisibleAxes();
 	jogAxes.Clear();
+	clampedAxes.Clear();
 	for (size_t axis = 0; axis < numVisibleAxes; ++axis)
 	{
 		const float limit = MaxSpeedForAxis(axis);
+		if (fabsf(requestedSpeeds[axis]) > limit)
+		{
+			clampedAxes.SetBit(axis);					// the host asked for more than M203 allows; say so rather than silently obeying something else
+		}
 		requestedSpeeds[axis] = constrain<float>(requestedSpeeds[axis], -limit, limit);
 		// A speed below one chunk's minimum distance cannot be expressed at all, so treat it as zero rather
 		// than as a jog that generates nothing. Otherwise the axis counts as jogging, keeps the machine out
@@ -78,6 +84,17 @@ void JogController::ReportStatus(const StringRef& reply) const noexcept
 	const char *_ecv_array const axisLetters = gcodes.GetAxisLetters();
 	reply.printf("Jogging %s, chunk %" PRIu32 "ms, timeout %" PRIu32 "ms, queue %u",
 					(active) ? "active" : "inactive", chunkMillis, timeoutMillis, maxQueuedMoves);
+	if (clampedAxes.IsNonEmpty())
+	{
+		reply.cat(", clamped to axis maximum:");
+		for (size_t axis = 0; axis < gcodes.GetVisibleAxes(); ++axis)
+		{
+			if (clampedAxes.IsBitSet(axis))
+			{
+				reply.catf(" %c%.1f", axisLetters[axis], (double)InverseConvertSpeedToMmPerSec(requestedSpeeds[axis]));
+			}
+		}
+	}
 	if (active)
 	{
 		reply.cat(", speeds");

--- a/src/Movement/JogController.h
+++ b/src/Movement/JogController.h
@@ -33,16 +33,22 @@ private:
 	void ClampSpeeds() noexcept;
 	void ReportStatus(const StringRef& reply) const noexcept;
 
-	static constexpr uint32_t DefaultChunkMillis = 50;
+	// Measured on the emulator, timing from command injection to the step pins changing rate:
+	//   D=5 P=50 -> 257ms    D=3 P=20 -> 126ms    D=2 P=20 -> 50ms
+	//   D=2 P=15 ->  62ms    D=2 P=10 -> 127ms
+	// Latency stops following D*P below about 40ms of queued motion and then gets worse, because Move
+	// wants roughly MoveTiming::UsualMinimumPreparedTime queued before it will run moves. So P=20/D=2
+	// is an optimum rather than a compromise - shortening either makes it slower, not faster.
+	// Doubling the command rate changed nothing (50.3 -> 50.0ms), so this is the firmware, not the host.
+	static constexpr uint32_t DefaultChunkMillis = 20;
 	static constexpr uint32_t MinChunkMillis = 10;
 	static constexpr uint32_t MaxChunkMillis = 200;
 	static constexpr uint32_t DefaultTimeoutMillis = 250;
 	static constexpr uint32_t MaxTimeoutMillis = 10000;
-	// Measured, not guessed. Under the Renode emulator a 20Hz M700 stream at 10mm/s stutters badly with
-	// a depth of 3 - velocity collapses to 2.5mm/s at chunk boundaries and 7% of the commanded distance
-	// is lost - because the producer cannot keep the ring topped up. 4 is clean; 5 leaves margin for a
-	// real machine, which has heaters, networking and the SD card competing for the same main loop.
-	static constexpr unsigned int DefaultMaxQueuedMoves = 5;
+	// 2 with a 20ms chunk measured clean - no stutter over a 20Hz stream - and is what gets latency to
+	// 50ms. The earlier stutter at depth 3 was with 50ms chunks, where the ring holds far more time and
+	// the producer has correspondingly longer to fall behind.
+	static constexpr unsigned int DefaultMaxQueuedMoves = 2;
 	static constexpr unsigned int MinMaxQueuedMoves = 2;
 	static constexpr unsigned int MaxMaxQueuedMoves = 8;
 

--- a/src/Movement/JogController.h
+++ b/src/Movement/JogController.h
@@ -38,7 +38,11 @@ private:
 	static constexpr uint32_t MaxChunkMillis = 200;
 	static constexpr uint32_t DefaultTimeoutMillis = 250;
 	static constexpr uint32_t MaxTimeoutMillis = 10000;
-	static constexpr unsigned int DefaultMaxQueuedMoves = 3;
+	// Measured, not guessed. Under the Renode emulator a 20Hz M700 stream at 10mm/s stutters badly with
+	// a depth of 3 - velocity collapses to 2.5mm/s at chunk boundaries and 7% of the commanded distance
+	// is lost - because the producer cannot keep the ring topped up. 4 is clean; 5 leaves margin for a
+	// real machine, which has heaters, networking and the SD card competing for the same main loop.
+	static constexpr unsigned int DefaultMaxQueuedMoves = 5;
 	static constexpr unsigned int MinMaxQueuedMoves = 2;
 	static constexpr unsigned int MaxMaxQueuedMoves = 8;
 

--- a/src/Movement/JogController.h
+++ b/src/Movement/JogController.h
@@ -33,13 +33,16 @@ private:
 	void ClampSpeeds() noexcept;
 	void ReportStatus(const StringRef& reply) const noexcept;
 
-	// Measured on the emulator, timing from command injection to the step pins changing rate:
-	//   D=5 P=50 -> 257ms    D=3 P=20 -> 126ms    D=2 P=20 -> 50ms
-	//   D=2 P=15 ->  62ms    D=2 P=10 -> 127ms
-	// Latency stops following D*P below about 40ms of queued motion and then gets worse, because Move
-	// wants roughly MoveTiming::UsualMinimumPreparedTime queued before it will run moves. So P=20/D=2
-	// is an optimum rather than a compromise - shortening either makes it slower, not faster.
-	// Doubling the command rate changed nothing (50.3 -> 50.0ms), so this is the firmware, not the host.
+	// Latency is dominated by the chunk time already queued ahead of the change: the chunks are a FIFO
+	// and a new speed takes effect only once the queued ones have run. Measured on the emulator, command
+	// injection to the step pins changing rate, D=2: P=15 -> 44.6ms, P=20 -> 38.5ms, P=25 -> 67.2ms,
+	// P=30 -> 90.2ms, and P=10 cannot sustain 15mm/s at all (see MaxSpeedForAxis). So P=20/D=2 is a real
+	// optimum: shortening P makes it worse, not better. Sizing the chunk adaptively to the requested
+	// speed - short chunk for a slow jog - was tried and is much worse (3->15mm/s: 39.5 -> 75.4ms;
+	// 1->3mm/s: 79 -> 245ms). Whatever sets the floor below ~40ms of queued motion, it is not the
+	// queue arithmetic, and two plausible culprits were measured and cleared: MoveTiming's preparation
+	// window (halving UsualMinimumPreparedTime to 25ms moved 50.3 -> 50.2ms) and the lookahead grace
+	// period (M595 R0 is worth about 2ms). Doubling the host command rate changed nothing either.
 	static constexpr uint32_t DefaultChunkMillis = 20;
 	static constexpr uint32_t MinChunkMillis = 10;
 	static constexpr uint32_t MaxChunkMillis = 200;

--- a/src/Movement/JogController.h
+++ b/src/Movement/JogController.h
@@ -1,0 +1,55 @@
+/*
+ * JogController.h
+ *
+ * Velocity-mode movement: axes are commanded by signed speed rather than by destination, so that a
+ * joystick or similar analogue input can drive them directly.
+ *
+ * The commanded velocity vector is turned into a stream of short constant-velocity moves that are fed
+ * into movement system 0. Lookahead blends consecutive chunks, and because the last move in the ring is
+ * always planned to end at zero speed, a stream that stops arriving decelerates the machine normally
+ * instead of stopping it dead.
+ */
+
+#ifndef SRC_MOVEMENT_JOGCONTROLLER_H_
+#define SRC_MOVEMENT_JOGCONTROLLER_H_
+
+#include <RepRapFirmware.h>
+
+class MovementState;
+
+class JogController
+{
+public:
+	JogController() noexcept;
+
+	GCodeResult ProcessM700(GCodeBuffer& gb, const StringRef& reply) THROWS(GCodeException);
+	void Spin() noexcept;								// keep the movement queue topped up; called from GCodes::Spin
+	void Stop() noexcept;								// stop jogging; queued motion decelerates to a halt
+	bool IsActive() const noexcept { return active; }
+
+private:
+	bool GenerateChunk(MovementState& ms) noexcept;
+	float MaxSpeedForAxis(size_t axis) const noexcept;
+	void ClampSpeeds() noexcept;
+	void ReportStatus(const StringRef& reply) const noexcept;
+
+	static constexpr uint32_t DefaultChunkMillis = 50;
+	static constexpr uint32_t MinChunkMillis = 10;
+	static constexpr uint32_t MaxChunkMillis = 200;
+	static constexpr uint32_t DefaultTimeoutMillis = 250;
+	static constexpr uint32_t MaxTimeoutMillis = 10000;
+	static constexpr unsigned int DefaultMaxQueuedMoves = 3;
+	static constexpr unsigned int MinMaxQueuedMoves = 2;
+	static constexpr unsigned int MaxMaxQueuedMoves = 8;
+
+	float requestedSpeeds[MaxAxes];						// signed commanded speed per axis, in mm (or degrees) per step clock
+	AxesBitmap jogAxes;									// the axes with a non-zero commanded speed
+	uint32_t chunkMillis;								// how much travel time one chunk represents
+	uint32_t chunkClocks;								// the same, in step clocks
+	uint32_t timeoutMillis;								// speeds are zeroed if no fresh command arrives within this time
+	uint32_t whenLastCommanded;
+	unsigned int maxQueuedMoves;						// bounds both the response latency and the distance available to stop in
+	volatile bool active;								// written by the GCode task, read by the same task only, but kept volatile for clarity
+};
+
+#endif /* SRC_MOVEMENT_JOGCONTROLLER_H_ */

--- a/src/Movement/JogController.h
+++ b/src/Movement/JogController.h
@@ -43,7 +43,7 @@ private:
 	// queue arithmetic, and two plausible culprits were measured and cleared: MoveTiming's preparation
 	// window (halving UsualMinimumPreparedTime to 25ms moved 50.3 -> 50.2ms) and the lookahead grace
 	// period (M595 R0 is worth about 2ms). Doubling the host command rate changed nothing either.
-	static constexpr uint32_t DefaultChunkMillis = 20;
+	static constexpr uint32_t DefaultChunkMillis = 15;
 	static constexpr uint32_t MinChunkMillis = 10;
 	static constexpr uint32_t MaxChunkMillis = 200;
 	static constexpr uint32_t DefaultTimeoutMillis = 250;
@@ -51,12 +51,27 @@ private:
 	// 2 with a 20ms chunk measured clean - no stutter over a 20Hz stream - and is what gets latency to
 	// 50ms. The earlier stutter at depth 3 was with 50ms chunks, where the ring holds far more time and
 	// the producer has correspondingly longer to fall behind.
-	static constexpr unsigned int DefaultMaxQueuedMoves = 2;
+	// Blending depends on how MANY moves are queued; stopping distance depends on how much TIME they
+	// represent. Those are separable, which is why the defaults are a deep queue of short chunks rather
+	// than a shallow queue of long ones. Measured at 100mm/s on a two-driver axis:
+	//   D2  P20 (old)  53% of commanded delivered
+	//   D6  P10        57% delivered   - short chunks do not give the planner enough to blend
+	//   D10 P6         62% delivered   - nor does adding more of them (reproduced 3/3)
+	//   D6  P20        93% delivered, S0 stops in 156ms
+	//   D8  P15        97% delivered, S0 stops in 153ms  (reproduced 2/2)   <- these defaults
+	// Shrinking P to cut the queued time was the obvious way to make S0 stop sooner while keeping
+	// enough moves to blend. It does not work: blending needs chunks long enough to be worth planning
+	// together, not merely numerous, so P below about 15ms costs a third of the commanded speed.
+	// A move with no successor is planned to stop within itself, and a 2mm chunk decelerating to rest
+	// takes 2.sqrt(d/a) = 89ms rather than its nominal 20ms. That, not any task handoff, is what used
+	// to leave a dead gap after every chunk.
+	static constexpr unsigned int DefaultMaxQueuedMoves = 8;
 	static constexpr unsigned int MinMaxQueuedMoves = 2;
-	static constexpr unsigned int MaxMaxQueuedMoves = 8;
+	static constexpr unsigned int MaxMaxQueuedMoves = 16;
 
 	float requestedSpeeds[MaxAxes];						// signed commanded speed per axis, in mm (or degrees) per step clock
-	AxesBitmap jogAxes;									// the axes with a non-zero commanded speed
+	AxesBitmap jogAxes;
+	AxesBitmap clampedAxes;								// axes whose requested speed was reduced to the axis maximum									// the axes with a non-zero commanded speed
 	uint32_t chunkMillis;								// how much travel time one chunk represents
 	uint32_t chunkClocks;								// the same, in step clocks
 	uint32_t timeoutMillis;								// speeds are zeroed if no fresh command arrives within this time

--- a/src/Movement/Move.cpp
+++ b/src/Movement/Move.cpp
@@ -173,6 +173,7 @@ constexpr ObjectModelTableEntry Move::objectModelTable[] =
 	{ "accelerationTime",		OBJECT_MODEL_FUNC(self->accelerationTime * StepClocksToSeconds, 3),								ObjectModelEntryFlags::notPanelDue },
 #endif
 	{ "axes",					OBJECT_MODEL_FUNC_ARRAY(0), 																	ObjectModelEntryFlags::live },
+	{ "axisFollower",			OBJECT_MODEL_FUNC_NOSELF(&reprap.GetGCodes().GetAxisFollower()),								ObjectModelEntryFlags::live },
 	{ "backlashFactor",			OBJECT_MODEL_FUNC((int32_t)self->GetBacklashCorrectionDistanceFactor()),						ObjectModelEntryFlags::none },
 	{ "calibration",			OBJECT_MODEL_FUNC(self, 3),																		ObjectModelEntryFlags::notPanelDue },
 	{ "compensation",			OBJECT_MODEL_FUNC(self, 6),																		ObjectModelEntryFlags::none },
@@ -344,7 +345,7 @@ constexpr ObjectModelTableEntry Move::objectModelTable[] =
 constexpr uint8_t Move::objectModelTableDescriptor[] =
 {
 	16 + SUPPORT_COORDINATE_ROTATION,										// number of sections
-	19 + SUPPORT_COORDINATE_ROTATION + SUPPORT_KEEPOUT_ZONES + 2 * SUPPORT_3RD_ORDER,	// section 0
+	20 + SUPPORT_COORDINATE_ROTATION + SUPPORT_KEEPOUT_ZONES + 2 * SUPPORT_3RD_ORDER,		// section 0 (20 includes axisFollower)
 	2,																		// section 1
 	8 + SUPPORT_LASER,														// section 2
 	3,																		// section 3

--- a/src/Platform/RepRap.cpp
+++ b/src/Platform/RepRap.cpp
@@ -1936,7 +1936,12 @@ size_t RepRap::GetStatusIndex() const noexcept
 			  		  : 												  9		// Printing
 			  	  	)
 			: (gCodes->IsDoingToolChange())								? 10	// Changing tool
-			: (gCodes->DoingFileMacro() || !move->NoLiveMovement() ||
+			// Jog motion deliberately does not count as busy. Jogging is continuous by nature, so it would
+			// pin the status at "busy" for as long as the operator holds the stick, and clients such as DWC
+			// and AxisControl grey their controls out when busy - including the very controls sending the
+			// jog commands. The machine is manually controlled and accepting commands, which is idle.
+			: (gCodes->DoingFileMacro() ||
+			   (!move->NoLiveMovement() && !gCodes->GetJogController().IsActive()) ||
 			   gCodes->WaitingForAcknowledgement() ||
 			   heat->IsTuningHeater())									? 11	// Busy
 			:															  12;	// Idle


### PR DESCRIPTION
Makes one axis track another **as part of the same coordinated move**, rather than reacting to it after the fact.

The motivating case is a Z-independent dust shoe on a U axis: the shoe is carried on the Z carriage, so U must move the opposite way as Z plunges to keep the bristles on the material. Done with G-code macros polling Z and issuing corrective moves, this visibly lags. Done in the planner, it does not.

```
M604 A"<follower>" B"<leader>" [S<scale>] [O<offset>] [E<0|1>]
```

`A` is the driven axis, `B` the tracked one, `S` the scale (default **-1**, since a follower carried on the leader must move the opposite way to stay put), `O` an offset, `E` engages or disengages. The rule is `follower = S * leader + O` in machine coordinates, clamped to the follower's `M208` limits. No parameters reports state.

Engaging without `O` captures the current relationship, so the follower does not jump when it engages. Engaging is refused if the follower is not homed.

**How it works.** `AxisFollower::Apply` runs at the end of `ToolOffsetTransform`, so following applies to every kind of motion - straight moves, arcs, and jogging - without any of them knowing about it.

**Measured skew** between leader and follower: **0.0000 ms** across straight moves, helical arcs and jogging, on an emulator with step pulses timestamped on the parallel IO port.

Also exposed in the object model as `move.axisFollower` (engaged, follower, leader, offset, scale) so a UI can show the state.

Documented in `Developer-documentation/Axis following (M604).md`.

---

**Two things to know before reviewing:**

1. **This branch stacks on the M700 branch.** Of the 9 commits, the first 6 are the velocity-jogging PR and only the last 3 are M604. `AxisFollower` touches `JogController` so the two cannot be separated cleanly. Review the last three commits, or merge M700 first and this will shrink to them.
2. **The command number is a proposal**, same as M700 - happy to renumber