### PR TITLE
Fix FTP upload receive-buffer lifetime in DoUpload

### DIFF
--- a/src/Networking/FtpResponder.cpp
+++ b/src/Networking/FtpResponder.cpp
@@ -403,8 +403,9 @@ void FtpResponder::DoUpload() noexcept
 			GetPlatform().MessageF(UsbMessage, "Writing %u bytes of upload data\n", len);
 		}
 
+		const bool ok = fileBeingUploaded.Write(buffer, len);
 		dataSocket->Taken(len);
-		if (!fileBeingUploaded.Write(buffer, len))
+		if (!ok)
 		{
 			uploadError = true;
 			GetPlatform().Message(ErrorMessage, "FTP: could not write upload data\n");


### PR DESCRIPTION
_Contributed on behalf of Vision Miner._
This contribution was developed as part of my work for Vision Miner and is submitted on the company’s behalf. Could you confirm whether an individual CLA with employer authorization is sufficient, or whether you require a Corporate CLA from Vision Miner?

FTP uploads can report success while saving corrupted data. We found fragments of unrelated network traffic in uploaded G-code files.
`FtpResponder::DoUpload()` calls `Taken(len)` before writing the received data to the file. On `lwIP`, this can free the buffer before it is read. The fix writes the data before releasing the buffer.

## Reproduction
1. Use a printer connected over Ethernet with FTP enabled and a test file of a few MB (expected.gcode). Set the printer and broadcast addresses in the scripts for your test network.
2. Run the UDP Stress Tester and FTP Integrity Checker concurrently on the same LAN.
3. Adjust the UDP burst size and pause until there is enough traffic to trigger corruption while FTP transfers still complete. If FTP stalls or times out, reduce the traffic rate.
4. Check for MISMATCH after successful uploads and downloads; the script saves affected files as bad-*.gcode. Repeat the same workload with the fix applied to compare results.

### Full reproduction scripts

#### UDP Stress Tester
```
import socket, time
s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
payload = (b'VMFLOOD-' * 182)[:1450]
while True:
    for _ in range(20):
        s.sendto(payload, ('192.168.0.255', 1900)) # <- adjust ip
    time.sleep(0.01)
```
#### FTP Integrity Checker
```
P=192.168.0.100 # <- adjust ip
for i in $(seq 1 100); do
  curl -sS -T expected.gcode "ftp://$P/gcodes/b$i.gcode"
  curl -sS "ftp://$P/gcodes/b$i.gcode" -o back.gcode
  cmp -s expected.gcode back.gcode || { echo ">>> MISMATCH $i"; cp back.gcode "bad-$i.gcode"; }
done
echo "done"
```

## Testing

Tested on a Duet 3 MB6HC over Ethernet using a 4 MB G-code file and concurrent UDP broadcast traffic.

| Firmware | fix | Observed result |
|---|---|---|
| 3.7-dev | No | Uploaded files contained `VMFLOOD` fragments from unrelated UDP traffic. |
| 3.7-dev | Yes | No `VMFLOOD` fragments were observed, but some files were truncated. |
| 3.5.4 | Yes | All 7 tested upload/download cycles matched the original file. |

The patched 3.7-dev build corresponds to commit bb1d98f915087f3958967988321773163e922ff8.

The remaining truncation in 3.7-dev appears to be a separate issue(https://github.com/Duet3D/RepRapFirmware/pull/1281). In one example, the returned file matched the beginning of the original but was missing its final 4,185 bytes:

- [Original file](https://github.com/user-attachments/files/32109529/expected.gcode.txt): 4,000,205 bytes.
- [Truncated file](https://github.com/user-attachments/files/32109533/back.gcode.txt): 3,996,020 bytes.