### PR TITLE
fix issue where an aborted FTP transfer was counted as successful

### DIFF
--- a/src/Networking/FtpResponder.cpp
+++ b/src/Networking/FtpResponder.cpp
@@ -418,6 +418,12 @@ void FtpResponder::DoUpload() noexcept
 	// Upload has finished if the connection is closed
 	if (!dataSocket->CanRead())
 	{
+		if (dataSocket->ConnectionWasAborted())
+		{
+			uploadError = true;
+			GetPlatform().Message(ErrorMessage, "FTP: upload connection was reset\n");
+		}
+
 		dataSocket = nullptr;
 		responderState = ResponderState::pasvTransferComplete;
 

--- a/src/Networking/LwipEthernet/LwipSocket.cpp
+++ b/src/Networking/LwipEthernet/LwipSocket.cpp
@@ -208,6 +208,7 @@ void LwipSocket::ConnectionClosedGracefully() noexcept
 
 void LwipSocket::ConnectionError(err_t err) noexcept
 {
+	connectionAborted = true;
 	if (reprap.Debug(Module::Network))
 	{
 		debugPrintf("LWIP socket error: proto=%d lport=%u rport=%u state=%d err=%d\n", (int)protocol, localPort, remotePort, (int)state, (int)err);
@@ -259,6 +260,7 @@ void LwipSocket::ReInit() noexcept
 	DiscardReceivedData();
 	whenConnected = whenWritten = whenClosed = 0;
 	responderFound = false;
+	connectionAborted = false;
 	readIndex = unAcked = 0;
 	txShutdownRequested = false;
 }

--- a/src/Networking/LwipEthernet/LwipSocket.h
+++ b/src/Networking/LwipEthernet/LwipSocket.h
@@ -49,6 +49,7 @@ public:
 	bool ReadBuffer(const uint8_t *&buffer, size_t &len) noexcept override;
 	void Taken(size_t len) noexcept override;
 	bool CanRead() const noexcept override;
+	bool ConnectionWasAborted() const noexcept override { return connectionAborted; }
 	bool CanSend() const noexcept override;
 	size_t Send(const uint8_t *data, size_t length) noexcept override;
 	void Send() noexcept override { }
@@ -75,6 +76,7 @@ private:
 	uint32_t whenWritten;
 	uint32_t whenClosed;
 	bool responderFound;
+	bool connectionAborted;
 
 	altcp_pcb *connectionPcb;
 #if LWIP_ALTCP_TLS

--- a/src/Networking/Socket.h
+++ b/src/Networking/Socket.h
@@ -44,6 +44,7 @@ public:
 	virtual bool ReadBuffer(const uint8_t *_ecv_array &buffer, size_t &len) noexcept = 0;
 	virtual void Taken(size_t len) noexcept = 0;
 	virtual bool CanRead() const noexcept = 0;
+	virtual bool ConnectionWasAborted() const noexcept { return false; }
 	virtual bool CanSend() const noexcept = 0;
 	virtual size_t Send(const uint8_t *_ecv_array data, size_t length) noexcept = 0;
 	virtual void Send() noexcept = 0;


### PR DESCRIPTION
_Contributed on behalf of Vision Miner._
This contribution was developed as part of my work for Vision Miner and is submitted on the company’s behalf. Could you confirm whether an individual CLA with employer authorization is sufficient, or whether you require a Corporate CLA from Vision Miner?

An FTP upload whose data connection is reset can still receive `226 Transfer complete`.
The fix records connection errors in `LwipSocket` and checks that state before finishing the upload. This uses the existing failure response and failed-upload cleanup path.

## Reproduction
1. Use a printer with FTP enabled. Set HOST and the login credentials in the script for your test device.
2. Run the script. It sends 4 MiB over a passive FTP data connection, then resets that connection with TCP RST while keeping the control connection open.
3. Check the final reply, then repeat with the fix applied. Before the fix, the server returns `226 Transfer complete`; with the fix, it returns `526 Transfer failed`.

### Full reproduction script
```
import socket, struct

HOST, SIZE = '192.168.0.100', 4 * 1024 * 1024   # <- adjust ip

ctrl = socket.create_connection((HOST, 21), timeout=10)
f = ctrl.makefile('rw', encoding='latin-1', newline='')
def cmd(line=None):
    if line: f.write(line + '\r\n'); f.flush()
    return f.readline().strip()

print(cmd()); print(cmd('USER username')); print(cmd('PASS password')); print(cmd('TYPE I'))
r = cmd('PASV')                                  # 227 ... (a,b,c,d,p1,p2)
n = [int(x) for x in r[r.index('(')+1:r.index(')')].split(',')]
data = socket.create_connection((HOST, n[4]*256 + n[5]), timeout=10)
print(cmd('STOR /gcodes/abort-test.gcode'))      # 150

chunk, sent = b';' + b'B'*4094 + b'\n', 0
while sent < SIZE:
    data.sendall(chunk); sent += len(chunk)

data.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
data.close()                                     # <- RST instead of FIN

print('reply after reset:', cmd())          # 226 = bug, 526 = fixed
```

## Testing

Tested on a Duet 3 MB6HC running RRF 3.5.4 and 3.7-dev. The patched 3.7-dev build corresponds to commit 64b755b187bbbdb7ae76c51bd6ea3d093c328785.

On unpatched firmware, the reset upload was incorrectly reported as successful. With the fix applied, it was reported as failed, and the false-success response no longer occurred in our tests.

### Without the fix
```
220 RepRapFirmware FTP server
331 Please specify the password.
230 Login successful.
200 Switching to Binary mode.
150 OK to send data.
reply after reset: 226 Transfer complete.
```

### With the fix
```
220 RepRapFirmware FTP server
331 Please specify the password.
230 Login successful.
200 Switching to Binary mode.
150 OK to send data.
reply after reset: 526 Transfer failed!
```