### PR TITLE
Fix FTP upload truncation caused by discarding unread receive buffers

### DIFF
--- a/src/Networking/LwipEthernet/LwipSocket.cpp
+++ b/src/Networking/LwipEthernet/LwipSocket.cpp
@@ -176,7 +176,9 @@ void LwipSocket::DataSent(size_t numBytes) noexcept
 
 void LwipSocket::ConnectionClosedGracefully() noexcept
 {
-	if (connectionPcb != nullptr)
+	// A FIN can arrive before the responder has consumed the last receive buffers.
+	// Keep the PCB until they are consumed so that closing it does not send a reset.
+	if (connectionPcb != nullptr && receivedData == nullptr)
 	{
 		altcp_err(connectionPcb, nullptr);
 		altcp_recv(connectionPcb, nullptr);
@@ -515,7 +517,7 @@ void LwipSocket::Poll() noexcept
 		}
 
 		const bool canFinalize = timeoutExceeded
-			|| (state == SocketState::peerDisconnecting && unAcked == 0)
+			|| (state == SocketState::peerDisconnecting && receivedData == nullptr && unAcked == 0)
 			|| (isTlsConnection && state == SocketState::closing && unAcked == 0);
 		if (canFinalize && connectionPcb != nullptr)
 		{
@@ -547,7 +549,8 @@ void LwipSocket::Poll() noexcept
 			}
 		}
 
-		if (connectionPcb == nullptr)
+		// Closing the TCP connection does not mean the responder has read all its data.
+		if (connectionPcb == nullptr && (receivedData == nullptr || timeoutExceeded))
 		{
 			DiscardReceivedData();
 			state = (localPort == 0 || outgoing) ? SocketState::disabled : SocketState::listening;


### PR DESCRIPTION
_Contributed on behalf of Vision Miner._
This contribution was developed as part of my work for Vision Miner and is submitted on the company’s behalf. Could you confirm whether an individual CLA with employer authorization is sufficient, or whether you require a Corporate CLA from Vision Miner?

FTP uploads can report success while saving a truncated file. The uploaded G-code file matched the beginning of the original but was missing its final bytes.

`LwipSocket` can discard queued receive buffers after TCP FIN, before the FTP responder consumes them. The fix defers graceful TCP closure until those buffers have been consumed and preserves unread data after PCB closure, while retaining the existing timeout handling.

## Reproduction

1. Use a printer connected over Ethernet with FTP enabled and a test file of a few MB (`expected.gcode`). Apply the separate receive-buffer UAF fix to both builds to isolate truncation from buffer corruption. Set the printer address in the script for your test network.
2. Run the FTP Integrity Checker to repeatedly upload and download the file.
3. Check for `MISMATCH` after successful uploads and downloads; the script saves affected files as `bad-*.gcode`. Compare their lengths and contents with the original.

### Full reproduction script

#### FTP Integrity Checker

```bash
P=192.168.0.100 # <- adjust ip
for i in $(seq 1 100); do
  curl -sS -T expected.gcode "ftp://$P/gcodes/b$i.gcode"
  curl -sS "ftp://$P/gcodes/b$i.gcode" -o back.gcode
  cmp -s expected.gcode back.gcode || { echo ">>> MISMATCH $i"; cp back.gcode "bad-$i.gcode"; }
done
echo "done"
```

## Testing

Reproduced on a Duet 3 MB6HC over Ethernet running 3.7-dev at commit bb1d98f915087f3958967988321773163e922ff8. This build includes the separate receive-buffer UAF fix but does not include the socket-close fix.

The 4,000,205-byte test file was saved as 3,996,020 bytes, losing its final 4,185 bytes. All preceding bytes matched the original. The shorter size was confirmed on the controller, and downloading the file again returned the same truncated content.

- [Original file](https://github.com/user-attachments/files/32109529/expected.gcode.txt): 4,000,205 bytes.
- [Truncated file](https://github.com/user-attachments/files/32109533/back.gcode.txt): 3,996,020 bytes.